### PR TITLE
[RISCV] Add Ji Qiu to the AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Jay Freeman <saurik@saurik.com>
 James Pike <g00gle@chilon.net>
 James M Snell <jasnell@gmail.com>
 Javad Amiri <javad.amiri@anu.edu.au>
+Ji Qiu <qiuji@iscas.ac.cn>
 Jianghua Yang <jianghua.yjh@alibaba-inc.com>
 Jiawen Geng <technicalcute@gmail.com>
 Jiaxun Yang <jiaxun.yang@flygoat.com>


### PR DESCRIPTION
Ji Qiu is a contributor of RISC-V backend.