### PR TITLE
Load Store Instructions Ported to RV32 in src/builtins and macro-assembler

### DIFF
--- a/src/baseline/riscv32/baseline-assembler-riscv32-inl.h
+++ b/src/baseline/riscv32/baseline-assembler-riscv32-inl.h
@@ -160,7 +160,7 @@ void BaselineAssembler::JumpIfInstanceType(Condition cc, Register map,
     __ GetObjectType(map, type, type);
     __ Assert(eq, AbortReason::kUnexpectedValue, type, Operand(MAP_TYPE));
   }
-  __ Ld(type, FieldMemOperand(map, Map::kInstanceTypeOffset));
+  __ Lw(type, FieldMemOperand(map, Map::kInstanceTypeOffset));
   __ Branch(target, AsMasmCondition(cc), type, Operand(instance_type));
 }
 void BaselineAssembler::JumpIfPointer(Condition cc, Register value,
@@ -168,7 +168,7 @@ void BaselineAssembler::JumpIfPointer(Condition cc, Register value,
                                       Label::Distance) {
   ScratchRegisterScope temps(this);
   Register temp = temps.AcquireScratch();
-  __ Ld(temp, operand);
+  __ Lw(temp, operand);
   __ Branch(target, AsMasmCondition(cc), value, Operand(temp));
 }
 void BaselineAssembler::JumpIfSmi(Condition cc, Register value, Smi smi,
@@ -192,7 +192,7 @@ void BaselineAssembler::JumpIfTagged(Condition cc, Register value,
   // todo: compress pointer
   ScratchRegisterScope temps(this);
   Register scratch = temps.AcquireScratch();
-  __ Ld(scratch, operand);
+  __ Lw(scratch, operand);
   __ Branch(target, AsMasmCondition(cc), value, Operand(scratch));
 }
 void BaselineAssembler::JumpIfTagged(Condition cc, MemOperand operand,
@@ -201,7 +201,7 @@ void BaselineAssembler::JumpIfTagged(Condition cc, MemOperand operand,
   // todo: compress pointer
   ScratchRegisterScope temps(this);
   Register scratch = temps.AcquireScratch();
-  __ Ld(scratch, operand);
+  __ Lw(scratch, operand);
   __ Branch(target, AsMasmCondition(cc), scratch, Operand(value));
 }
 void BaselineAssembler::JumpIfByte(Condition cc, Register value, int32_t byte,
@@ -216,7 +216,7 @@ void BaselineAssembler::Move(Register output, TaggedIndex value) {
   __ li(output, Operand(value.ptr()));
 }
 void BaselineAssembler::Move(MemOperand output, Register source) {
-  __ Sd(source, output);
+  __ Sw(source, output);
 }
 void BaselineAssembler::Move(Register output, ExternalReference reference) {
   __ li(output, Operand(reference));

--- a/src/baseline/riscv32/baseline-compiler-riscv32-inl.h
+++ b/src/baseline/riscv32/baseline-compiler-riscv32-inl.h
@@ -41,7 +41,7 @@ void BaselineCompiler::PrologueFillFrame() {
     DCHECK_LE(new_target_index, register_count);
     __ masm()->Add(sp, sp, Operand(-(kPointerSize * new_target_index)));
     for (int i = 0; i < new_target_index; i++) {
-      __ masm()->Sd(kInterpreterAccumulatorRegister, MemOperand(sp, i * 8));
+      __ masm()->Sw(kInterpreterAccumulatorRegister, MemOperand(sp, i * 8));
     }
     // Push new_target_or_generator.
     __ Push(kJavaScriptCallNewTargetRegister);
@@ -51,12 +51,12 @@ void BaselineCompiler::PrologueFillFrame() {
     // If the frame is small enough, just unroll the frame fill completely.
     __ masm()->Add(sp, sp, Operand(-(kPointerSize * register_count)));
     for (int i = 0; i < register_count; ++i) {
-      __ masm()->Sd(kInterpreterAccumulatorRegister, MemOperand(sp, i * 8));
+      __ masm()->Sw(kInterpreterAccumulatorRegister, MemOperand(sp, i * 8));
     }
   } else {
     __ masm()->Add(sp, sp, Operand(-(kPointerSize * register_count)));
     for (int i = 0; i < register_count; ++i) {
-      __ masm()->Sd(kInterpreterAccumulatorRegister, MemOperand(sp, i * 8));
+      __ masm()->Sw(kInterpreterAccumulatorRegister, MemOperand(sp, i * 8));
     }
   }
 }

--- a/src/builtins/riscv32/builtins-riscv32.cc
+++ b/src/builtins/riscv32/builtins-riscv32.cc
@@ -84,9 +84,9 @@ void Generate_PushArguments(MacroAssembler* masm, Register array, Register argc,
   __ Branch(&entry);
   __ bind(&loop);
   __ CalcScaledAddress(scratch2, array, scratch, kSystemPointerSizeLog2);
-  __ Ld(scratch2, MemOperand(scratch2));
+  __ Lw(scratch2, MemOperand(scratch2));
   if (element_type == ArgumentsElementType::kHandle) {
-    __ Ld(scratch2, MemOperand(scratch2));
+    __ Lw(scratch2, MemOperand(scratch2));
   }
   __ push(scratch2);
   __ bind(&entry);
@@ -135,9 +135,9 @@ void Generate_JSBuiltinsConstructStubHelper(MacroAssembler* masm) {
     __ InvokeFunctionWithNewTarget(a1, a3, a0, InvokeType::kCall);
 
     // Restore context from the frame.
-    __ Ld(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
+    __ Lw(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
     // Restore smi-tagged arguments count from the frame.
-    __ Ld(kScratchReg, MemOperand(fp, ConstructFrameConstants::kLengthOffset));
+    __ Lw(kScratchReg, MemOperand(fp, ConstructFrameConstants::kLengthOffset));
     // Leave construct frame.
   }
 
@@ -184,7 +184,7 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
     Register func_info = temps.Acquire();
     __ LoadTaggedPointerField(
         func_info, FieldMemOperand(a1, JSFunction::kSharedFunctionInfoOffset));
-    __ Lwu(func_info,
+    __ Lw(func_info,
            FieldMemOperand(func_info, SharedFunctionInfo::kFlagsOffset));
     __ DecodeField<SharedFunctionInfo::FunctionKindBits>(func_info);
     __ JumpIfIsInRange(
@@ -245,8 +245,8 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
   // -----------------------------------
 
   // Restore constructor function and argument count.
-  __ Ld(a1, MemOperand(fp, ConstructFrameConstants::kConstructorOffset));
-  __ Ld(a0, MemOperand(fp, ConstructFrameConstants::kLengthOffset));
+  __ Lw(a1, MemOperand(fp, ConstructFrameConstants::kConstructorOffset));
+  __ Lw(a0, MemOperand(fp, ConstructFrameConstants::kLengthOffset));
   __ SmiUntag(a0);
 
   Label stack_overflow;
@@ -290,7 +290,7 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
       masm->pc_offset());
 
   // Restore the context from the frame.
-  __ Ld(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
+  __ Lw(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
 
   // If the result is an object (in the ECMA sense), we should get rid
   // of the receiver and use the result; see ECMA-262 section 13.2.2-7
@@ -306,12 +306,12 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
   // Throw away the result of the constructor invocation and use the
   // on-stack receiver as the result.
   __ bind(&use_receiver);
-  __ Ld(a0, MemOperand(sp, 0 * kSystemPointerSize));
+  __ Lw(a0, MemOperand(sp, 0 * kSystemPointerSize));
   __ JumpIfRoot(a0, RootIndex::kTheHoleValue, &do_throw);
 
   __ bind(&leave_and_return);
   // Restore smi-tagged arguments count from the frame.
-  __ Ld(a1, MemOperand(fp, ConstructFrameConstants::kLengthOffset));
+  __ Lw(a1, MemOperand(fp, ConstructFrameConstants::kLengthOffset));
   // Leave construct frame.
   __ LeaveFrame(StackFrame::CONSTRUCT);
 
@@ -337,13 +337,13 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
   }
   __ bind(&do_throw);
   // Restore the context from the frame.
-  __ Ld(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
+  __ Lw(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
   __ CallRuntime(Runtime::kThrowConstructorReturnedNonObject);
   __ break_(0xCC);
 
   __ bind(&stack_overflow);
   // Restore the context from the frame.
-  __ Ld(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
+  __ Lw(cp, MemOperand(fp, ConstructFrameConstants::kContextOffset));
   __ CallRuntime(Runtime::kThrowStackOverflow);
   __ break_(0xCC);
 }
@@ -356,7 +356,7 @@ static void AssertCodeIsBaseline(MacroAssembler* masm, Register code,
                                  Register scratch) {
   DCHECK(!AreAliased(code, scratch));
   // Verify that the code kind is baseline code via the CodeKind.
-  __ Ld(scratch, FieldMemOperand(code, Code::kFlagsOffset));
+  __ Lw(scratch, FieldMemOperand(code, Code::kFlagsOffset));
   __ DecodeField<Code::KindField>(scratch);
   __ Assert(eq, AbortReason::kExpectedBaselineData, scratch,
             Operand(static_cast<int64_t>(CodeKind::BASELINE)));
@@ -417,7 +417,7 @@ void Builtins::Generate_ResumeGeneratorTrampoline(MacroAssembler* masm) {
   ExternalReference debug_suspended_generator =
       ExternalReference::debug_suspended_generator_address(masm->isolate());
   __ li(a5, debug_suspended_generator);
-  __ Ld(a5, MemOperand(a5));
+  __ Lw(a5, MemOperand(a5));
   __ Branch(&prepare_step_in_suspended_generator, eq, a1, Operand(a5));
   __ bind(&stepping_prepared);
 
@@ -617,13 +617,13 @@ void Generate_JSEntryVariant(MacroAssembler* masm, StackFrame::Type type,
   ExternalReference c_entry_fp = ExternalReference::Create(
       IsolateAddressId::kCEntryFPAddress, masm->isolate());
   __ li(s5, c_entry_fp);
-  __ Ld(s4, MemOperand(s5));
+  __ Lw(s4, MemOperand(s5));
   __ Push(s1, s2, s3, s4);
   // Clear c_entry_fp, now we've pushed its previous value to the stack.
   // If the c_entry_fp is not already zero and we don't clear it, the
   // SafeStackFrameIterator will assume we are executing C++ and miss the JS
   // frames on top.
-  __ Sd(zero_reg, MemOperand(s5));
+  __ Sw(zero_reg, MemOperand(s5));
   // Set up frame pointer for the frame to be pushed.
   __ Add(fp, sp, -EntryFrameConstants::kCallerFPOffset);
   // Registers:
@@ -650,10 +650,10 @@ void Generate_JSEntryVariant(MacroAssembler* masm, StackFrame::Type type,
   ExternalReference js_entry_sp = ExternalReference::Create(
       IsolateAddressId::kJSEntrySPAddress, masm->isolate());
   __ li(s1, js_entry_sp);
-  __ Ld(s2, MemOperand(s1));
+  __ Lw(s2, MemOperand(s1));
   __ Branch(&non_outermost_js, ne, s2, Operand(zero_reg),
             Label::Distance::kNear);
-  __ Sd(fp, MemOperand(s1));
+  __ Sw(fp, MemOperand(s1));
   __ li(s3, Operand(StackFrame::OUTERMOST_JSENTRY_FRAME));
   Label cont;
   __ Branch(&cont);
@@ -677,7 +677,7 @@ void Generate_JSEntryVariant(MacroAssembler* masm, StackFrame::Type type,
   // signal the existence of the JSEntry frame.
   __ li(s1, ExternalReference::Create(
                 IsolateAddressId::kPendingExceptionAddress, masm->isolate()));
-  __ Sd(a0, MemOperand(s1));  // We come back from 'invoke'. result is in a0.
+  __ Sw(a0, MemOperand(s1));  // We come back from 'invoke'. result is in a0.
   __ LoadRoot(a0, RootIndex::kException);
   __ BranchShort(&exit);
 
@@ -726,14 +726,14 @@ void Generate_JSEntryVariant(MacroAssembler* masm, StackFrame::Type type,
             Operand(StackFrame::OUTERMOST_JSENTRY_FRAME),
             Label::Distance::kNear);
   __ li(a5, js_entry_sp);
-  __ Sd(zero_reg, MemOperand(a5));
+  __ Sw(zero_reg, MemOperand(a5));
   __ bind(&non_outermost_js_2);
 
   // Restore the top frame descriptors from the stack.
   __ pop(a5);
   __ li(a4, ExternalReference::Create(IsolateAddressId::kCEntryFPAddress,
                                       masm->isolate()));
-  __ Sd(a5, MemOperand(a4));
+  __ Sw(a5, MemOperand(a4));
 
   // Reset the stack to the callee saved registers.
   __ Add(sp, sp, -EntryFrameConstants::kCallerFPOffset);
@@ -781,7 +781,7 @@ static void Generate_JSEntryTrampolineHelper(MacroAssembler* masm,
     ExternalReference context_address = ExternalReference::Create(
         IsolateAddressId::kContextAddress, masm->isolate());
     __ li(cp, context_address);
-    __ Ld(cp, MemOperand(cp));
+    __ Lw(cp, MemOperand(cp));
 
     // Push the function onto the stack.
     __ Push(a2);
@@ -870,7 +870,7 @@ static void LeaveInterpreterFrame(MacroAssembler* masm, Register scratch1,
   Register params_size = scratch1;
 
   // Get the size of the formal parameters + receiver (in bytes).
-  __ Ld(params_size,
+  __ Lw(params_size,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
   __ Lw(params_size,
         FieldMemOperand(params_size, BytecodeArray::kParameterSizeOffset));
@@ -878,7 +878,7 @@ static void LeaveInterpreterFrame(MacroAssembler* masm, Register scratch1,
   Register actual_params_size = scratch2;
   Label L1;
   // Compute the size of the actual parameters + receiver (in bytes).
-  __ Ld(actual_params_size,
+  __ Lw(actual_params_size,
         MemOperand(fp, StandardFrameConstants::kArgCOffset));
   __ Sll64(actual_params_size, actual_params_size, kSystemPointerSizeLog2);
   // If actual is bigger than formal, then we should use it to free up the stack
@@ -1122,9 +1122,9 @@ void Builtins::Generate_BaselineOutOfLinePrologue(MacroAssembler* masm) {
       BaselineOutOfLinePrologueDescriptor::kClosure);
   // Load the feedback vector from the closure.
   Register feedback_vector = temps.Acquire();
-  __ Ld(feedback_vector,
+  __ Lw(feedback_vector,
         FieldMemOperand(closure, JSFunction::kFeedbackCellOffset));
-  __ Ld(feedback_vector, FieldMemOperand(feedback_vector, Cell::kValueOffset));
+  __ Lw(feedback_vector, FieldMemOperand(feedback_vector, Cell::kValueOffset));
   if (FLAG_debug_code) {
     UseScratchRegisterScope temps(masm);
     Register type = temps.Acquire();
@@ -1390,7 +1390,7 @@ void Builtins::Generate_InterpreterEntryTrampoline(MacroAssembler* masm) {
   __ Branch(&no_incoming_new_target_or_generator_register, eq, a5,
             Operand(zero_reg), Label::Distance::kNear);
   __ CalcScaledAddress(a5, fp, a5, kSystemPointerSizeLog2);
-  __ Sd(a3, MemOperand(a5));
+  __ Sw(a3, MemOperand(a5));
   __ bind(&no_incoming_new_target_or_generator_register);
 
   // Perform interrupt stack check.
@@ -1415,7 +1415,7 @@ void Builtins::Generate_InterpreterEntryTrampoline(MacroAssembler* masm) {
   __ Lbu(a7, MemOperand(a1));
   __ CalcScaledAddress(kScratchReg, kInterpreterDispatchTableRegister, a7,
                        kSystemPointerSizeLog2);
-  __ Ld(kJavaScriptCallCodeStartRegister, MemOperand(kScratchReg));
+  __ Lw(kJavaScriptCallCodeStartRegister, MemOperand(kScratchReg));
   __ Call(kJavaScriptCallCodeStartRegister);
   masm->isolate()->heap()->SetInterpreterEntryReturnPCOffset(masm->pc_offset());
 
@@ -1423,9 +1423,9 @@ void Builtins::Generate_InterpreterEntryTrampoline(MacroAssembler* masm) {
   // or the interpreter tail calling a builtin and then a dispatch.
 
   // Get bytecode array and bytecode offset from the stack frame.
-  __ Ld(kInterpreterBytecodeArrayRegister,
+  __ Lw(kInterpreterBytecodeArrayRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
-  __ Ld(kInterpreterBytecodeOffsetRegister,
+  __ Lw(kInterpreterBytecodeOffsetRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
   __ SmiUntag(kInterpreterBytecodeOffsetRegister);
 
@@ -1450,21 +1450,21 @@ void Builtins::Generate_InterpreterEntryTrampoline(MacroAssembler* masm) {
   __ li(kInterpreterBytecodeOffsetRegister,
         Operand(Smi::FromInt(BytecodeArray::kHeaderSize - kHeapObjectTag +
                              kFunctionEntryBytecodeOffset)));
-  __ Sd(kInterpreterBytecodeOffsetRegister,
+  __ Sw(kInterpreterBytecodeOffsetRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
   __ CallRuntime(Runtime::kStackGuard);
 
   // After the call, restore the bytecode array, bytecode offset and accumulator
   // registers again. Also, restore the bytecode offset in the stack to its
   // previous value.
-  __ Ld(kInterpreterBytecodeArrayRegister,
+  __ Lw(kInterpreterBytecodeArrayRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
   __ li(kInterpreterBytecodeOffsetRegister,
         Operand(BytecodeArray::kHeaderSize - kHeapObjectTag));
   __ LoadRoot(kInterpreterAccumulatorRegister, RootIndex::kUndefinedValue);
 
   __ SmiTag(a5, kInterpreterBytecodeOffsetRegister);
-  __ Sd(a5, MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
+  __ Sw(a5, MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
 
   __ Branch(&after_stack_check_interrupt);
 
@@ -1564,7 +1564,7 @@ void Builtins::Generate_InterpreterPushArgsThenCallImpl(
     // Pass the spread in the register a2.
     // a2 already points to the penultime argument, the spread
     // is below that.
-    __ Ld(a2, MemOperand(a2, -kSystemPointerSize));
+    __ Lw(a2, MemOperand(a2, -kSystemPointerSize));
   }
 
   // Call the target.
@@ -1613,7 +1613,7 @@ void Builtins::Generate_InterpreterPushArgsThenConstructImpl(
     // Pass the spread in the register a2.
     // a4 already points to the penultimate argument, the spread
     // lies in the next interpreter register.
-    __ Ld(a2, MemOperand(a4, -kSystemPointerSize));
+    __ Lw(a2, MemOperand(a4, -kSystemPointerSize));
   } else {
     __ AssertUndefinedOrAllocationSite(a2, t0);
   }
@@ -1655,7 +1655,7 @@ static void Generate_InterpreterEnterBytecode(MacroAssembler* masm) {
   // custom copy of the interpreter entry trampoline for profiling. If so,
   // get the custom trampoline, otherwise grab the entry address of the global
   // trampoline.
-  __ Ld(t0, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
+  __ Lw(t0, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
   __ LoadTaggedPointerField(
       t0, FieldMemOperand(t0, JSFunction::kSharedFunctionInfoOffset));
   __ LoadTaggedPointerField(
@@ -1674,7 +1674,7 @@ static void Generate_InterpreterEnterBytecode(MacroAssembler* masm) {
   __ li(t0, ExternalReference::
                 address_of_interpreter_entry_trampoline_instruction_start(
                     masm->isolate()));
-  __ Ld(t0, MemOperand(t0));
+  __ Lw(t0, MemOperand(t0));
 
   __ bind(&trampoline_loaded);
   __ Add(ra, t0, Operand(interpreter_entry_return_pc_offset.value()));
@@ -1684,7 +1684,7 @@ static void Generate_InterpreterEnterBytecode(MacroAssembler* masm) {
         ExternalReference::interpreter_dispatch_table_address(masm->isolate()));
 
   // Get the bytecode array pointer from the frame.
-  __ Ld(kInterpreterBytecodeArrayRegister,
+  __ Lw(kInterpreterBytecodeArrayRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
 
   if (FLAG_debug_code) {
@@ -1719,7 +1719,7 @@ static void Generate_InterpreterEnterBytecode(MacroAssembler* masm) {
   __ Lbu(a7, MemOperand(a1));
   __ CalcScaledAddress(a1, kInterpreterDispatchTableRegister, a7,
                        kSystemPointerSizeLog2);
-  __ Ld(kJavaScriptCallCodeStartRegister, MemOperand(a1));
+  __ Lw(kJavaScriptCallCodeStartRegister, MemOperand(a1));
   __ Jump(kJavaScriptCallCodeStartRegister);
 }
 
@@ -1727,9 +1727,9 @@ void Builtins::Generate_InterpreterEnterAtNextBytecode(MacroAssembler* masm) {
   // Advance the current bytecode offset stored within the given interpreter
   // stack frame. This simulates what all bytecode handlers do upon completion
   // of the underlying operation.
-  __ Ld(kInterpreterBytecodeArrayRegister,
+  __ Lw(kInterpreterBytecodeArrayRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
-  __ Ld(kInterpreterBytecodeOffsetRegister,
+  __ Lw(kInterpreterBytecodeOffsetRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
   __ SmiUntag(kInterpreterBytecodeOffsetRegister);
 
@@ -1752,7 +1752,7 @@ void Builtins::Generate_InterpreterEnterAtNextBytecode(MacroAssembler* masm) {
   __ bind(&enter_bytecode);
   // Convert new bytecode offset to a Smi and save in the stackframe.
   __ SmiTag(a2, kInterpreterBytecodeOffsetRegister);
-  __ Sd(a2, MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
+  __ Sw(a2, MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
 
   Generate_InterpreterEnterBytecode(masm);
 
@@ -1788,7 +1788,7 @@ void Generate_ContinueToBuiltinHelper(MacroAssembler* masm,
     } else {
       // Overwrite the hole inserted by the deoptimizer with the return value
       // from the LAZY deopt point.
-      __ Sd(a0,
+      __ Sw(a0,
             MemOperand(sp,
                        config->num_allocatable_general_registers() *
                                kSystemPointerSize +
@@ -1812,12 +1812,12 @@ void Generate_ContinueToBuiltinHelper(MacroAssembler* masm,
         kJSArgcReceiverSlots;
     __ Add(a0, a0, Operand(return_value_offset));
     __ CalcScaledAddress(t0, sp, a0, kSystemPointerSizeLog2);
-    __ Sd(scratch, MemOperand(t0));
+    __ Sw(scratch, MemOperand(t0));
     // Recover arguments count.
     __ Sub(a0, a0, Operand(return_value_offset));
   }
 
-  __ Ld(fp, MemOperand(
+  __ Lw(fp, MemOperand(
                 sp, BuiltinContinuationFrameConstants::kFixedFrameSizeFromFp));
   // Load builtin index (stored as a Smi) and use it to get the builtin start
   // address from the builtins table.
@@ -1855,7 +1855,7 @@ void Builtins::Generate_NotifyDeoptimized(MacroAssembler* masm) {
   }
 
   DCHECK_EQ(kInterpreterAccumulatorRegister.code(), a0.code());
-  __ Ld(a0, MemOperand(sp, 0 * kSystemPointerSize));
+  __ Lw(a0, MemOperand(sp, 0 * kSystemPointerSize));
   __ Add(sp, sp, Operand(1 * kSystemPointerSize));  // Remove state.
   __ Ret();
 }
@@ -1907,7 +1907,7 @@ void Builtins::Generate_InterpreterOnStackReplacement(MacroAssembler* masm) {
 }
 
 void Builtins::Generate_BaselineOnStackReplacement(MacroAssembler* masm) {
-  __ Ld(kContextRegister,
+  __ Lw(kContextRegister,
         MemOperand(fp, StandardFrameConstants::kContextOffset));
   return OnStackReplacement(masm, false);
 }
@@ -1936,8 +1936,8 @@ void Builtins::Generate_FunctionPrototypeApply(MacroAssembler* masm) {
     // Claim (2 - argc) dummy arguments form the stack, to put the stack in a
     // consistent state for a simple pop operation.
 
-    __ Ld(this_arg, MemOperand(sp, kSystemPointerSize));
-    __ Ld(arg_array, MemOperand(sp, 2 * kSystemPointerSize));
+    __ Lw(this_arg, MemOperand(sp, kSystemPointerSize));
+    __ Lw(arg_array, MemOperand(sp, 2 * kSystemPointerSize));
 
     Label done0, done1;
     UseScratchRegisterScope temps(masm);
@@ -1952,7 +1952,7 @@ void Builtins::Generate_FunctionPrototypeApply(MacroAssembler* masm) {
     __ Move(arg_array, undefined_value);  // if argc == 1
     __ bind(&done1);                      // else (i.e., argc > 1)
 
-    __ Ld(receiver, MemOperand(sp));
+    __ Lw(receiver, MemOperand(sp));
     __ DropArgumentsAndPushNewReceiver(argc, this_arg,
                                        MacroAssembler::kCountIsInteger,
                                        MacroAssembler::kCountIncludesReceiver);
@@ -2036,9 +2036,9 @@ void Builtins::Generate_ReflectApply(MacroAssembler* masm) {
     // Claim (3 - argc) dummy arguments form the stack, to put the stack in a
     // consistent state for a simple pop operation.
 
-    __ Ld(target, MemOperand(sp, kSystemPointerSize));
-    __ Ld(this_argument, MemOperand(sp, 2 * kSystemPointerSize));
-    __ Ld(arguments_list, MemOperand(sp, 3 * kSystemPointerSize));
+    __ Lw(target, MemOperand(sp, kSystemPointerSize));
+    __ Lw(this_argument, MemOperand(sp, 2 * kSystemPointerSize));
+    __ Lw(arguments_list, MemOperand(sp, 3 * kSystemPointerSize));
 
     Label done0, done1, done2;
     UseScratchRegisterScope temps(masm);
@@ -2103,9 +2103,9 @@ void Builtins::Generate_ReflectConstruct(MacroAssembler* masm) {
   {
     // Claim (3 - argc) dummy arguments form the stack, to put the stack in a
     // consistent state for a simple pop operation.
-    __ Ld(target, MemOperand(sp, kSystemPointerSize));
-    __ Ld(arguments_list, MemOperand(sp, 2 * kSystemPointerSize));
-    __ Ld(new_target, MemOperand(sp, 3 * kSystemPointerSize));
+    __ Lw(target, MemOperand(sp, kSystemPointerSize));
+    __ Lw(arguments_list, MemOperand(sp, 2 * kSystemPointerSize));
+    __ Lw(new_target, MemOperand(sp, 3 * kSystemPointerSize));
 
     Label done0, done1, done2;
     UseScratchRegisterScope temps(masm);
@@ -2180,8 +2180,8 @@ void Generate_AllocateSpaceAndShiftExistingArguments(
   Label loop, done;
   __ Branch(&done, ge, old_sp, Operand(end));
   __ bind(&loop);
-  __ Ld(value, MemOperand(old_sp, 0));
-  __ Sd(value, MemOperand(dest, 0));
+  __ Lw(value, MemOperand(old_sp, 0));
+  __ Sw(value, MemOperand(dest, 0));
   __ Add(old_sp, old_sp, Operand(kSystemPointerSize));
   __ Add(dest, dest, Operand(kSystemPointerSize));
   __ Branch(&loop, lt, old_sp, Operand(end));
@@ -2254,7 +2254,7 @@ void Builtins::Generate_CallOrConstructVarargs(MacroAssembler* masm,
     __ Branch(&push, ne, a5, Operand(hole_value), Label::Distance::kNear);
     __ LoadRoot(a5, RootIndex::kUndefinedValue);
     __ bind(&push);
-    __ Sd(a5, MemOperand(a7, 0));
+    __ Sw(a5, MemOperand(a7, 0));
     __ Add(a7, a7, Operand(kSystemPointerSize));
     __ Add(scratch, scratch, Operand(kTaggedSize));
     __ Branch(&loop, ne, scratch, Operand(sp));
@@ -2306,7 +2306,7 @@ void Builtins::Generate_CallOrConstructForwardVarargs(MacroAssembler* masm,
   // TODO(victorgomes): Remove this copy when all the arguments adaptor frame
   // code is erased.
   __ Move(a6, fp);
-  __ Ld(a7, MemOperand(fp, StandardFrameConstants::kArgCOffset));
+  __ Lw(a7, MemOperand(fp, StandardFrameConstants::kArgCOffset));
 
   Label stack_done, stack_overflow;
   __ Sub(a7, a7, Operand(kJSArgcReceiverSlots));
@@ -2342,9 +2342,9 @@ void Builtins::Generate_CallOrConstructForwardVarargs(MacroAssembler* masm,
         Register scratch = temps.Acquire(), addr = temps.Acquire();
         __ Sub(a7, a7, Operand(1));
         __ CalcScaledAddress(addr, a6, a7, kSystemPointerSizeLog2);
-        __ Ld(scratch, MemOperand(addr));
+        __ Lw(scratch, MemOperand(addr));
         __ CalcScaledAddress(addr, a2, a7, kSystemPointerSizeLog2);
-        __ Sd(scratch, MemOperand(addr));
+        __ Sw(scratch, MemOperand(addr));
         __ Branch(&loop, ne, a7, Operand(zero_reg));
       }
     }
@@ -2370,7 +2370,7 @@ void Builtins::Generate_CallFunction(MacroAssembler* masm,
   Label class_constructor;
   __ LoadTaggedPointerField(
       a2, FieldMemOperand(a1, JSFunction::kSharedFunctionInfoOffset));
-  __ Lwu(a3, FieldMemOperand(a2, SharedFunctionInfo::kFlagsOffset));
+  __ Lw(a3, FieldMemOperand(a2, SharedFunctionInfo::kFlagsOffset));
   __ And(kScratchReg, a3,
          Operand(SharedFunctionInfo::IsClassConstructorBit::kMask));
   __ Branch(&class_constructor, ne, kScratchReg, Operand(zero_reg));
@@ -2382,7 +2382,7 @@ void Builtins::Generate_CallFunction(MacroAssembler* masm,
                             FieldMemOperand(a1, JSFunction::kContextOffset));
   // We need to convert the receiver for non-native sloppy mode functions.
   Label done_convert;
-  __ Lwu(a3, FieldMemOperand(a2, SharedFunctionInfo::kFlagsOffset));
+  __ Lw(a3, FieldMemOperand(a2, SharedFunctionInfo::kFlagsOffset));
   __ And(kScratchReg, a3,
          Operand(SharedFunctionInfo::IsNativeBit::kMask |
                  SharedFunctionInfo::IsStrictBit::kMask));
@@ -2647,7 +2647,7 @@ void Builtins::Generate_ConstructFunction(MacroAssembler* masm) {
   // Jump to JSBuiltinsConstructStub or JSConstructStubGeneric.
   __ LoadTaggedPointerField(
       a4, FieldMemOperand(a1, JSFunction::kSharedFunctionInfoOffset));
-  __ Lwu(a4, FieldMemOperand(a4, SharedFunctionInfo::kFlagsOffset));
+  __ Lw(a4, FieldMemOperand(a4, SharedFunctionInfo::kFlagsOffset));
   __ And(a4, a4, Operand(SharedFunctionInfo::ConstructAsBuiltinBit::kMask));
   __ Branch(&call_generic_stub, eq, a4, Operand(zero_reg),
             Label::Distance::kNear);
@@ -2889,7 +2889,7 @@ void Builtins::Generate_CEntry(MacroAssembler* masm, int result_size,
     ExternalReference pending_exception_address = ExternalReference::Create(
         IsolateAddressId::kPendingExceptionAddress, masm->isolate());
     __ li(a2, pending_exception_address);
-    __ Ld(a2, MemOperand(a2));
+    __ Lw(a2, MemOperand(a2));
     __ LoadRoot(a4, RootIndex::kTheHoleValue);
     // Cannot use check here as it attempts to generate call into runtime.
     __ Branch(&okay, eq, a4, Operand(a2), Label::Distance::kNear);
@@ -2936,24 +2936,24 @@ void Builtins::Generate_CEntry(MacroAssembler* masm, int result_size,
 
   // Retrieve the handler context, SP and FP.
   __ li(cp, pending_handler_context_address);
-  __ Ld(cp, MemOperand(cp));
+  __ Lw(cp, MemOperand(cp));
   __ li(sp, pending_handler_sp_address);
-  __ Ld(sp, MemOperand(sp));
+  __ Lw(sp, MemOperand(sp));
   __ li(fp, pending_handler_fp_address);
-  __ Ld(fp, MemOperand(fp));
+  __ Lw(fp, MemOperand(fp));
 
   // If the handler is a JS frame, restore the context to the frame. Note that
   // the context will be set to (cp == 0) for non-JS frames.
   Label zero;
   __ Branch(&zero, eq, cp, Operand(zero_reg), Label::Distance::kNear);
-  __ Sd(cp, MemOperand(fp, StandardFrameConstants::kContextOffset));
+  __ Sw(cp, MemOperand(fp, StandardFrameConstants::kContextOffset));
   __ bind(&zero);
 
   // Compute the handler entry address and jump to it.
   UseScratchRegisterScope temp(masm);
   Register scratch = temp.Acquire();
   __ li(scratch, pending_handler_entrypoint_address);
-  __ Ld(scratch, MemOperand(scratch));
+  __ Lw(scratch, MemOperand(scratch));
   __ Jump(scratch);
 }
 
@@ -3073,7 +3073,7 @@ void Builtins::Generate_DoubleToI(MacroAssembler* masm) {
 
   __ bind(&done);
 
-  __ Sd(result_reg, MemOperand(sp, kArgumentOffset));
+  __ Sw(result_reg, MemOperand(sp, kArgumentOffset));
   __ Pop(scratch, scratch2, scratch3);
   __ Pop(result_reg);
   __ Ret();
@@ -3158,8 +3158,8 @@ void CallApiFunctionAndReturn(MacroAssembler* masm, Register function_address,
 
     // Allocate HandleScope in callee-save registers.
     __ li(s5, next_address);
-    __ Ld(s3, MemOperand(s5, kNextOffset));
-    __ Ld(s1, MemOperand(s5, kLimitOffset));
+    __ Lw(s3, MemOperand(s5, kNextOffset));
+    __ Lw(s1, MemOperand(s5, kLimitOffset));
     __ Lw(s2, MemOperand(s5, kLevelOffset));
     __ Add(s2, s2, Operand(1));
     __ Sw(s2, MemOperand(s5, kLevelOffset));
@@ -3173,12 +3173,12 @@ void CallApiFunctionAndReturn(MacroAssembler* masm, Register function_address,
   Label return_value_loaded;
 
   // Load value from ReturnValue.
-  __ Ld(a0, return_value_operand);
+  __ Lw(a0, return_value_operand);
   __ bind(&return_value_loaded);
 
   // No more valid handles (the result handle was the last one). Restore
   // previous handle scope.
-  __ Sd(s3, MemOperand(s5, kNextOffset));
+  __ Sw(s3, MemOperand(s5, kNextOffset));
   if (FLAG_debug_code) {
     __ Lw(a1, MemOperand(s5, kLevelOffset));
     __ Check(eq, AbortReason::kUnexpectedLevelAfterReturnFromApiCall, a1,
@@ -3186,7 +3186,7 @@ void CallApiFunctionAndReturn(MacroAssembler* masm, Register function_address,
   }
   __ Sub(s2, s2, Operand(1));
   __ Sw(s2, MemOperand(s5, kLevelOffset));
-  __ Ld(kScratchReg, MemOperand(s5, kLimitOffset));
+  __ Lw(kScratchReg, MemOperand(s5, kLimitOffset));
   __ Branch(&delete_allocated_handles, ne, s1, Operand(kScratchReg));
 
   // Leave the API exit frame.
@@ -3198,7 +3198,7 @@ void CallApiFunctionAndReturn(MacroAssembler* masm, Register function_address,
   } else {
     DCHECK_EQ(stack_space, 0);
     STATIC_ASSERT(kCArgSlotCount == 0);
-    __ Ld(s3, *stack_space_operand);
+    __ Lw(s3, *stack_space_operand);
   }
 
   static constexpr bool kDontSaveDoubles = false;
@@ -3209,7 +3209,7 @@ void CallApiFunctionAndReturn(MacroAssembler* masm, Register function_address,
   // Check if the function scheduled an exception.
   __ LoadRoot(a4, RootIndex::kTheHoleValue);
   __ li(kScratchReg, ExternalReference::scheduled_exception_address(isolate));
-  __ Ld(a5, MemOperand(kScratchReg));
+  __ Lw(a5, MemOperand(kScratchReg));
   __ Branch(&promote_scheduled_exception, ne, a4, Operand(a5),
             Label::Distance::kNear);
 
@@ -3221,7 +3221,7 @@ void CallApiFunctionAndReturn(MacroAssembler* masm, Register function_address,
 
   // HandleScope limit has changed. Delete allocated extensions.
   __ bind(&delete_allocated_handles);
-  __ Sd(s1, MemOperand(s5, kLimitOffset));
+  __ Sw(s1, MemOperand(s5, kLimitOffset));
   __ Move(s3, a0);
   __ PrepareCallCFunction(1, s1);
   __ li(a0, ExternalReference::isolate_address(isolate));
@@ -3285,22 +3285,22 @@ void Builtins::Generate_CallApiCallback(MacroAssembler* masm) {
   __ Sub(sp, sp, Operand(FCA::kArgsLength * kSystemPointerSize));
 
   // kHolder.
-  __ Sd(holder, MemOperand(sp, 0 * kSystemPointerSize));
+  __ Sw(holder, MemOperand(sp, 0 * kSystemPointerSize));
 
   // kIsolate.
   __ li(scratch, ExternalReference::isolate_address(masm->isolate()));
-  __ Sd(scratch, MemOperand(sp, 1 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 1 * kSystemPointerSize));
 
   // kReturnValueDefaultValue and kReturnValue.
   __ LoadRoot(scratch, RootIndex::kUndefinedValue);
-  __ Sd(scratch, MemOperand(sp, 2 * kSystemPointerSize));
-  __ Sd(scratch, MemOperand(sp, 3 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 2 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 3 * kSystemPointerSize));
 
   // kData.
-  __ Sd(call_data, MemOperand(sp, 4 * kSystemPointerSize));
+  __ Sw(call_data, MemOperand(sp, 4 * kSystemPointerSize));
 
   // kNewTarget.
-  __ Sd(scratch, MemOperand(sp, 5 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 5 * kSystemPointerSize));
 
   // Keep a pointer to kHolder (= implicit_args) in a scratch register.
   // We use it below to set up the FunctionCallbackInfo object.
@@ -3317,13 +3317,13 @@ void Builtins::Generate_CallApiCallback(MacroAssembler* masm) {
 
   // FunctionCallbackInfo::implicit_args_ (points at kHolder as set up above).
   // Arguments are after the return address (pushed by EnterExitFrame()).
-  __ Sd(scratch, MemOperand(sp, 1 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 1 * kSystemPointerSize));
 
   // FunctionCallbackInfo::values_ (points at the first varargs argument passed
   // on the stack).
   __ Add(scratch, scratch,
          Operand((FCA::kArgsLength + 1) * kSystemPointerSize));
-  __ Sd(scratch, MemOperand(sp, 2 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 2 * kSystemPointerSize));
 
   // FunctionCallbackInfo::length_.
   // Stored as int field, 32-bit integers within struct on stack always left
@@ -3335,7 +3335,7 @@ void Builtins::Generate_CallApiCallback(MacroAssembler* masm) {
   // Note: Unlike on other architectures, this stores the number of slots to
   // drop, not the number of bytes.
   __ Add(scratch, argc, Operand(FCA::kArgsLength + 1 /* receiver */));
-  __ Sd(scratch, MemOperand(sp, 4 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 4 * kSystemPointerSize));
 
   // v8::InvocationCallback's argument.
   DCHECK(!AreAliased(api_function_address, scratch, a0));
@@ -3381,25 +3381,25 @@ void Builtins::Generate_CallApiGetter(MacroAssembler* masm) {
   // Here and below +1 is for name() pushed after the args_ array.
   using PCA = PropertyCallbackArguments;
   __ Sub(sp, sp, (PCA::kArgsLength + 1) * kSystemPointerSize);
-  __ Sd(receiver, MemOperand(sp, (PCA::kThisIndex + 1) * kSystemPointerSize));
+  __ Sw(receiver, MemOperand(sp, (PCA::kThisIndex + 1) * kSystemPointerSize));
   __ LoadAnyTaggedField(scratch,
                         FieldMemOperand(callback, AccessorInfo::kDataOffset));
-  __ Sd(scratch, MemOperand(sp, (PCA::kDataIndex + 1) * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, (PCA::kDataIndex + 1) * kSystemPointerSize));
   __ LoadRoot(scratch, RootIndex::kUndefinedValue);
-  __ Sd(scratch,
+  __ Sw(scratch,
         MemOperand(sp, (PCA::kReturnValueOffset + 1) * kSystemPointerSize));
-  __ Sd(scratch, MemOperand(sp, (PCA::kReturnValueDefaultValueIndex + 1) *
+  __ Sw(scratch, MemOperand(sp, (PCA::kReturnValueDefaultValueIndex + 1) *
                                     kSystemPointerSize));
   __ li(scratch, ExternalReference::isolate_address(masm->isolate()));
-  __ Sd(scratch, MemOperand(sp, (PCA::kIsolateIndex + 1) * kSystemPointerSize));
-  __ Sd(holder, MemOperand(sp, (PCA::kHolderIndex + 1) * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, (PCA::kIsolateIndex + 1) * kSystemPointerSize));
+  __ Sw(holder, MemOperand(sp, (PCA::kHolderIndex + 1) * kSystemPointerSize));
   // should_throw_on_error -> false
   DCHECK_EQ(0, Smi::zero().ptr());
-  __ Sd(zero_reg, MemOperand(sp, (PCA::kShouldThrowOnErrorIndex + 1) *
+  __ Sw(zero_reg, MemOperand(sp, (PCA::kShouldThrowOnErrorIndex + 1) *
                                      kSystemPointerSize));
   __ LoadTaggedPointerField(
       scratch, FieldMemOperand(callback, AccessorInfo::kNameOffset));
-  __ Sd(scratch, MemOperand(sp, 0 * kSystemPointerSize));
+  __ Sw(scratch, MemOperand(sp, 0 * kSystemPointerSize));
 
   // v8::PropertyCallbackInfo::args_ array and name handle.
   const int kStackUnwindSpace = PropertyCallbackArguments::kArgsLength + 1;
@@ -3414,7 +3414,7 @@ void Builtins::Generate_CallApiGetter(MacroAssembler* masm) {
 
   // Create v8::PropertyCallbackInfo object on the stack and initialize
   // it's args_ field.
-  __ Sd(a1, MemOperand(sp, 1 * kSystemPointerSize));
+  __ Sw(a1, MemOperand(sp, 1 * kSystemPointerSize));
   __ Add(a1, sp, Operand(1 * kSystemPointerSize));
   // a1 = v8::PropertyCallbackInfo&
 
@@ -3423,7 +3423,7 @@ void Builtins::Generate_CallApiGetter(MacroAssembler* masm) {
 
   __ LoadTaggedPointerField(
       scratch, FieldMemOperand(callback, AccessorInfo::kJsGetterOffset));
-  __ Ld(api_function_address,
+  __ Lw(api_function_address,
         FieldMemOperand(scratch, Foreign::kForeignAddressOffset));
 
   // +3 is to skip prolog, return address and name handle.
@@ -3450,9 +3450,9 @@ void Builtins::Generate_DirectCEntry(MacroAssembler* masm) {
   // after the call.
   __ Add(sp, sp, -kCArgsSlotsSize);
 
-  __ Sd(ra, MemOperand(sp, kCArgsSlotsSize));  // Store the return address.
+  __ Sw(ra, MemOperand(sp, kCArgsSlotsSize));  // Store the return address.
   __ Call(t6);                                 // Call the C++ function.
-  __ Ld(t6, MemOperand(sp, kCArgsSlotsSize));  // Return to calling code.
+  __ Lw(t6, MemOperand(sp, kCArgsSlotsSize));  // Return to calling code.
 
   if (FLAG_debug_code && FLAG_enable_slow_asserts) {
     // In case of an error the return address may point to a memory area
@@ -3497,13 +3497,13 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
   __ Sub(sp, sp, kNumberOfRegisters * kSystemPointerSize);
   for (int16_t i = kNumberOfRegisters - 1; i >= 0; i--) {
     if ((saved_regs.bits() & (1 << i)) != 0) {
-      __ Sd(ToRegister(i), MemOperand(sp, kSystemPointerSize * i));
+      __ Sw(ToRegister(i), MemOperand(sp, kSystemPointerSize * i));
     }
   }
 
   __ li(a2,
         ExternalReference::Create(IsolateAddressId::kCEntryFPAddress, isolate));
-  __ Sd(fp, MemOperand(a2));
+  __ Sw(fp, MemOperand(a2));
 
   const int kSavedRegistersAreaSize =
       (kNumberOfRegisters * kSystemPointerSize) + kDoubleRegsSize;
@@ -3521,9 +3521,9 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
   // Pass five arguments, according to n64 ABI.
   __ Move(a0, zero_reg);
   Label context_check;
-  __ Ld(a1, MemOperand(fp, CommonFrameConstants::kContextOrFrameTypeOffset));
+  __ Lw(a1, MemOperand(fp, CommonFrameConstants::kContextOrFrameTypeOffset));
   __ JumpIfSmi(a1, &context_check);
-  __ Ld(a0, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
+  __ Lw(a0, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
   __ bind(&context_check);
   __ li(a1, Operand(static_cast<int64_t>(deopt_kind)));
   // a2: code object address
@@ -3538,7 +3538,7 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
 
   // Preserve "deoptimizer" object in register a0 and get the input
   // frame descriptor pointer to a1 (deoptimizer->input_);
-  __ Ld(a1, MemOperand(a0, Deoptimizer::input_offset()));
+  __ Lw(a1, MemOperand(a0, Deoptimizer::input_offset()));
 
   // Copy core registers into FrameDescription::registers_[kNumRegisters].
   DCHECK_EQ(Register::kNumRegisters, kNumberOfRegisters);
@@ -3546,11 +3546,11 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
     int offset =
         (i * kSystemPointerSize) + FrameDescription::registers_offset();
     if ((saved_regs.bits() & (1 << i)) != 0) {
-      __ Ld(a2, MemOperand(sp, i * kSystemPointerSize));
-      __ Sd(a2, MemOperand(a1, offset));
+      __ Lw(a2, MemOperand(sp, i * kSystemPointerSize));
+      __ Sw(a2, MemOperand(a1, offset));
     } else if (FLAG_debug_code) {
       __ li(a2, kDebugZapValue);
-      __ Sd(a2, MemOperand(a1, offset));
+      __ Sw(a2, MemOperand(a1, offset));
     }
   }
 
@@ -3571,7 +3571,7 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
 
   // Compute a pointer to the unwinding limit in register a2; that is
   // the first stack slot not part of the input frame.
-  __ Ld(a2, MemOperand(a1, FrameDescription::frame_size_offset()));
+  __ Lw(a2, MemOperand(a1, FrameDescription::frame_size_offset()));
   __ Add(a2, a2, sp);
 
   // Unwind the stack down to - but not including - the unwinding
@@ -3583,7 +3583,7 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
   __ BranchShort(&pop_loop_header);
   __ bind(&pop_loop);
   __ pop(a4);
-  __ Sd(a4, MemOperand(a3, 0));
+  __ Sw(a4, MemOperand(a3, 0));
   __ Add(a3, a3, sizeof(uint64_t));
   __ bind(&pop_loop_header);
   __ Branch(&pop_loop, ne, a2, Operand(sp), Label::Distance::kNear);
@@ -3598,25 +3598,25 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
   }
   __ pop(a0);  // Restore deoptimizer object (class Deoptimizer).
 
-  __ Ld(sp, MemOperand(a0, Deoptimizer::caller_frame_top_offset()));
+  __ Lw(sp, MemOperand(a0, Deoptimizer::caller_frame_top_offset()));
 
   // Replace the current (input) frame with the output frames.
   Label outer_push_loop, inner_push_loop, outer_loop_header, inner_loop_header;
   // Outer loop state: a4 = current "FrameDescription** output_",
   // a1 = one past the last FrameDescription**.
   __ Lw(a1, MemOperand(a0, Deoptimizer::output_count_offset()));
-  __ Ld(a4, MemOperand(a0, Deoptimizer::output_offset()));  // a4 is output_.
+  __ Lw(a4, MemOperand(a0, Deoptimizer::output_offset()));  // a4 is output_.
   __ CalcScaledAddress(a1, a4, a1, kSystemPointerSizeLog2);
   __ BranchShort(&outer_loop_header);
   __ bind(&outer_push_loop);
   // Inner loop state: a2 = current FrameDescription*, a3 = loop index.
-  __ Ld(a2, MemOperand(a4, 0));  // output_[ix]
-  __ Ld(a3, MemOperand(a2, FrameDescription::frame_size_offset()));
+  __ Lw(a2, MemOperand(a4, 0));  // output_[ix]
+  __ Lw(a3, MemOperand(a2, FrameDescription::frame_size_offset()));
   __ BranchShort(&inner_loop_header);
   __ bind(&inner_push_loop);
   __ Sub(a3, a3, Operand(sizeof(uint64_t)));
   __ Add(a6, a2, Operand(a3));
-  __ Ld(a7, MemOperand(a6, FrameDescription::frame_content_offset()));
+  __ Lw(a7, MemOperand(a6, FrameDescription::frame_content_offset()));
   __ push(a7);
   __ bind(&inner_loop_header);
   __ Branch(&inner_push_loop, ne, a3, Operand(zero_reg));
@@ -3625,7 +3625,7 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
   __ bind(&outer_loop_header);
   __ Branch(&outer_push_loop, lt, a4, Operand(a1));
 
-  __ Ld(a1, MemOperand(a0, Deoptimizer::input_offset()));
+  __ Lw(a1, MemOperand(a0, Deoptimizer::input_offset()));
   for (int i = 0; i < config->num_allocatable_double_registers(); ++i) {
     int code = config->GetAllocatableDoubleCode(i);
     const DoubleRegister fpu_reg = DoubleRegister::from_code(code);
@@ -3634,9 +3634,9 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
   }
 
   // Push pc and continuation from the last output frame.
-  __ Ld(a6, MemOperand(a2, FrameDescription::pc_offset()));
+  __ Lw(a6, MemOperand(a2, FrameDescription::pc_offset()));
   __ push(a6);
-  __ Ld(a6, MemOperand(a2, FrameDescription::continuation_offset()));
+  __ Lw(a6, MemOperand(a2, FrameDescription::continuation_offset()));
   __ push(a6);
 
   // Technically restoring 't3' should work unless zero_reg is also restored
@@ -3648,7 +3648,7 @@ void Generate_DeoptimizationEntry(MacroAssembler* masm,
     int offset =
         (i * kSystemPointerSize) + FrameDescription::registers_offset();
     if ((restored_regs.bits() & (1 << i)) != 0) {
-      __ Ld(ToRegister(i), MemOperand(t3, offset));
+      __ Lw(ToRegister(i), MemOperand(t3, offset));
     }
   }
 
@@ -3682,7 +3682,7 @@ void Generate_BaselineOrInterpreterEntry(MacroAssembler* masm,
 
   // Get function from the frame.
   Register closure = a1;
-  __ Ld(closure, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
+  __ Lw(closure, MemOperand(fp, StandardFrameConstants::kFunctionOffset));
 
   // Get the Code object from the shared function info.
   Register code_obj = s1;
@@ -3741,7 +3741,7 @@ void Generate_BaselineOrInterpreterEntry(MacroAssembler* masm,
   __ SmiUntag(kInterpreterBytecodeOffsetRegister,
               MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
   // Replace BytecodeOffset with the feedback vector.
-  __ Sd(feedback_vector,
+  __ Sw(feedback_vector,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeOffsetFromFp));
   feedback_vector = no_reg;
 
@@ -3775,7 +3775,7 @@ void Generate_BaselineOrInterpreterEntry(MacroAssembler* masm,
 
   __ bind(&valid_bytecode_offset);
   // Get bytecode array from the stack frame.
-  __ Ld(kInterpreterBytecodeArrayRegister,
+  __ Lw(kInterpreterBytecodeArrayRegister,
         MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
   __ Push(kInterpreterAccumulatorRegister);
   {
@@ -3795,7 +3795,7 @@ void Generate_BaselineOrInterpreterEntry(MacroAssembler* masm,
     // Reset the OSR loop nesting depth to disarm back edges.
     // TODO(pthier): Separate baseline Sparkplug from TF arming and don't disarm
     // Sparkplug here.
-    __ Ld(kInterpreterBytecodeArrayRegister,
+    __ Lw(kInterpreterBytecodeArrayRegister,
           MemOperand(fp, InterpreterFrameConstants::kBytecodeArrayFromFp));
     __ Sh(zero_reg, FieldMemOperand(kInterpreterBytecodeArrayRegister,
                                     BytecodeArray::kOsrUrgencyOffset));

--- a/src/codegen/riscv32/macro-assembler-riscv32.h
+++ b/src/codegen/riscv32/macro-assembler-riscv32.h
@@ -199,7 +199,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
     li(rd, Operand(j), mode);
   }
 
-  inline void Move(Register output, MemOperand operand) { Ld(output, operand); }
+  inline void Move(Register output, MemOperand operand) { Lw(output, operand); }
   void li(Register dst, Handle<HeapObject> value,
           RelocInfo::Mode rmode = RelocInfo::FULL_EMBEDDED_OBJECT);
   void li(Register dst, ExternalReference value, LiFlags mode = OPTIMIZE_SIZE);
@@ -283,12 +283,9 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
 
   void DropAndRet(int drop, Condition cond, Register reg, const Operand& op);
 
-  void Ld(Register rd, const MemOperand& rs);
-  void Sd(Register rd, const MemOperand& rs);
-
   void push(Register src) {
     Add(sp, sp, Operand(-kSystemPointerSize));
-    Sd(src, MemOperand(sp, 0));
+    Sw(src, MemOperand(sp, 0));
   }
   void Push(Register src) { push(src); }
   void Push(Handle<HeapObject> handle);
@@ -297,43 +294,43 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   // Push two registers. Pushes leftmost register first (to highest address).
   void Push(Register src1, Register src2) {
     Sub(sp, sp, Operand(2 * kSystemPointerSize));
-    Sd(src1, MemOperand(sp, 1 * kSystemPointerSize));
-    Sd(src2, MemOperand(sp, 0 * kSystemPointerSize));
+    Sw(src1, MemOperand(sp, 1 * kSystemPointerSize));
+    Sw(src2, MemOperand(sp, 0 * kSystemPointerSize));
   }
 
   // Push three registers. Pushes leftmost register first (to highest address).
   void Push(Register src1, Register src2, Register src3) {
     Sub(sp, sp, Operand(3 * kSystemPointerSize));
-    Sd(src1, MemOperand(sp, 2 * kSystemPointerSize));
-    Sd(src2, MemOperand(sp, 1 * kSystemPointerSize));
-    Sd(src3, MemOperand(sp, 0 * kSystemPointerSize));
+    Sw(src1, MemOperand(sp, 2 * kSystemPointerSize));
+    Sw(src2, MemOperand(sp, 1 * kSystemPointerSize));
+    Sw(src3, MemOperand(sp, 0 * kSystemPointerSize));
   }
 
   // Push four registers. Pushes leftmost register first (to highest address).
   void Push(Register src1, Register src2, Register src3, Register src4) {
     Sub(sp, sp, Operand(4 * kSystemPointerSize));
-    Sd(src1, MemOperand(sp, 3 * kSystemPointerSize));
-    Sd(src2, MemOperand(sp, 2 * kSystemPointerSize));
-    Sd(src3, MemOperand(sp, 1 * kSystemPointerSize));
-    Sd(src4, MemOperand(sp, 0 * kSystemPointerSize));
+    Sw(src1, MemOperand(sp, 3 * kSystemPointerSize));
+    Sw(src2, MemOperand(sp, 2 * kSystemPointerSize));
+    Sw(src3, MemOperand(sp, 1 * kSystemPointerSize));
+    Sw(src4, MemOperand(sp, 0 * kSystemPointerSize));
   }
 
   // Push five registers. Pushes leftmost register first (to highest address).
   void Push(Register src1, Register src2, Register src3, Register src4,
             Register src5) {
     Sub(sp, sp, Operand(5 * kSystemPointerSize));
-    Sd(src1, MemOperand(sp, 4 * kSystemPointerSize));
-    Sd(src2, MemOperand(sp, 3 * kSystemPointerSize));
-    Sd(src3, MemOperand(sp, 2 * kSystemPointerSize));
-    Sd(src4, MemOperand(sp, 1 * kSystemPointerSize));
-    Sd(src5, MemOperand(sp, 0 * kSystemPointerSize));
+    Sw(src1, MemOperand(sp, 4 * kSystemPointerSize));
+    Sw(src2, MemOperand(sp, 3 * kSystemPointerSize));
+    Sw(src3, MemOperand(sp, 2 * kSystemPointerSize));
+    Sw(src4, MemOperand(sp, 1 * kSystemPointerSize));
+    Sw(src5, MemOperand(sp, 0 * kSystemPointerSize));
   }
 
   void Push(Register src, Condition cond, Register tst1, Register tst2) {
     // Since we don't have conditional execution we use a Branch.
     Branch(3, cond, tst1, Operand(tst2));
     Sub(sp, sp, Operand(kSystemPointerSize));
-    Sd(src, MemOperand(sp, 0));
+    Sw(src, MemOperand(sp, 0));
   }
 
   enum PushArrayOrder { kNormal, kReverse };
@@ -379,7 +376,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
                      Register exclusion3 = no_reg);
 
   void pop(Register dst) {
-    Ld(dst, MemOperand(sp, 0));
+    Lw(dst, MemOperand(sp, 0));
     Add(sp, sp, Operand(kSystemPointerSize));
   }
   void Pop(Register dst) { pop(dst); }
@@ -387,16 +384,16 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   // Pop two registers. Pops rightmost register first (from lower address).
   void Pop(Register src1, Register src2) {
     DCHECK(src1 != src2);
-    Ld(src2, MemOperand(sp, 0 * kSystemPointerSize));
-    Ld(src1, MemOperand(sp, 1 * kSystemPointerSize));
+    Lw(src2, MemOperand(sp, 0 * kSystemPointerSize));
+    Lw(src1, MemOperand(sp, 1 * kSystemPointerSize));
     Add(sp, sp, 2 * kSystemPointerSize);
   }
 
   // Pop three registers. Pops rightmost register first (from lower address).
   void Pop(Register src1, Register src2, Register src3) {
-    Ld(src3, MemOperand(sp, 0 * kSystemPointerSize));
-    Ld(src2, MemOperand(sp, 1 * kSystemPointerSize));
-    Ld(src1, MemOperand(sp, 2 * kSystemPointerSize));
+    Lw(src3, MemOperand(sp, 0 * kSystemPointerSize));
+    Lw(src2, MemOperand(sp, 1 * kSystemPointerSize));
+    Lw(src1, MemOperand(sp, 2 * kSystemPointerSize));
     Add(sp, sp, 3 * kSystemPointerSize);
   }
 
@@ -1022,11 +1019,11 @@ class V8_EXPORT_PRIVATE MacroAssembler : public TurboAssembler {
   // TODO(victorgomes): Remove this function once we stick with the reversed
   // arguments order.
   void LoadReceiver(Register dest, Register argc) {
-    Ld(dest, MemOperand(sp, 0));
+    Lw(dest, MemOperand(sp, 0));
   }
 
   void StoreReceiver(Register rec, Register argc, Register scratch) {
-    Sd(rec, MemOperand(sp, 0));
+    Sw(rec, MemOperand(sp, 0));
   }
 
   bool IsNear(Label* L, Condition cond, int rs_reg);
@@ -1337,7 +1334,7 @@ void TurboAssembler::GenerateSwitchTable(Register index, size_t case_count,
        kSystemPointerSizeLog2);  // scratch2 = offset of indexth entry
   add(scratch2, scratch2,
       scratch);  // scratch2 = (saved PC) + (offset of indexth entry)
-  ld(scratch2, scratch2,
+  lw(scratch2, scratch2,
      6 * kInstrSize);  // Add the size of these 6 instructions to the
                        // offset, then load
   jr(scratch2);        // Jump to the address loaded from the table

--- a/src/compiler/backend/riscv32/code-generator-riscv32.cc
+++ b/src/compiler/backend/riscv32/code-generator-riscv32.cc
@@ -551,8 +551,8 @@ void CodeGenerator::AssembleDeconstructFrame() {
 
 void CodeGenerator::AssemblePrepareTailCall() {
   if (frame_access_state()->has_frame()) {
-    __ Ld(ra, MemOperand(fp, StandardFrameConstants::kCallerPCOffset));
-    __ Ld(fp, MemOperand(fp, StandardFrameConstants::kCallerFPOffset));
+    __ Lw(ra, MemOperand(fp, StandardFrameConstants::kCallerPCOffset));
+    __ Lw(fp, MemOperand(fp, StandardFrameConstants::kCallerFPOffset));
   }
   frame_access_state()->SetFrameAccessToSP();
 }
@@ -764,7 +764,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       if (isWasmCapiFunction) {
         // Put the return address in a stack slot.
         __ LoadAddress(kScratchReg, &after_call, RelocInfo::EXTERNAL_REFERENCE);
-        __ Sd(kScratchReg,
+        __ Sw(kScratchReg,
               MemOperand(fp, WasmExitFrameConstants::kCallingPCOffset));
       }
       if (instr->InputAt(0)->IsImmediate()) {
@@ -848,7 +848,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       break;
     case kArchParentFramePointer:
       if (frame_access_state()->has_frame()) {
-        __ Ld(i.OutputRegister(), MemOperand(fp, 0));
+        __ Lw(i.OutputRegister(), MemOperand(fp, 0));
       } else {
         __ Move(i.OutputRegister(), fp);
       }
@@ -1605,7 +1605,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       __ Ulwu(i.OutputRegister(), i.MemoryOperand());
       break;
     case kRiscvLd:
-      __ Ld(i.OutputRegister(), i.MemoryOperand());
+      __ Lw(i.OutputRegister(), i.MemoryOperand());
       break;
     case kRiscvUld:
       __ Uld(i.OutputRegister(), i.MemoryOperand());
@@ -1617,7 +1617,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       __ Usw(i.InputOrZeroRegister(2), i.MemoryOperand());
       break;
     case kRiscvSd:
-      __ Sd(i.InputOrZeroRegister(2), i.MemoryOperand());
+      __ Sw(i.InputOrZeroRegister(2), i.MemoryOperand());
       break;
     case kRiscvUsd:
       __ Usd(i.InputOrZeroRegister(2), i.MemoryOperand());
@@ -1701,7 +1701,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
               MemOperand(fp, offset + kLessSignificantWordInDoublewordOffset));
         }
       } else {
-        __ Ld(i.OutputRegister(0), MemOperand(fp, offset));
+        __ Lw(i.OutputRegister(0), MemOperand(fp, offset));
       }
       break;
     }
@@ -1726,7 +1726,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
                          MemOperand(sp, i.InputInt32(1)));
         }
       } else {
-        __ Sd(i.InputOrZeroRegister(0), MemOperand(sp, i.InputInt32(1)));
+        __ Sw(i.InputOrZeroRegister(0), MemOperand(sp, i.InputInt32(1)));
       }
       break;
     }
@@ -1756,7 +1756,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       ASSEMBLE_ATOMIC_LOAD_INTEGER(Lw);
       break;
     case kRiscvWord64AtomicLoadUint64:
-      ASSEMBLE_ATOMIC_LOAD_INTEGER(Ld);
+      ASSEMBLE_ATOMIC_LOAD_INTEGER(Lw);
       break;
     case kAtomicStoreWord8:
       ASSEMBLE_ATOMIC_STORE_INTEGER(Sb);
@@ -1768,7 +1768,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       ASSEMBLE_ATOMIC_STORE_INTEGER(Sw);
       break;
     case kRiscvWord64AtomicStoreWord64:
-      ASSEMBLE_ATOMIC_STORE_INTEGER(Sd);
+      ASSEMBLE_ATOMIC_STORE_INTEGER(Sw);
       break;
     case kAtomicExchangeInt8:
       DCHECK_EQ(AtomicWidthField::decode(opcode), AtomicWidth::kWord32);
@@ -1968,7 +1968,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvS128Load64Zero: {
       Simd128Register dst = i.OutputSimd128Register();
       __ VU.set(kScratchReg, E64, m1);
-      __ Ld(kScratchReg, i.MemoryOperand());
+      __ Lw(kScratchReg, i.MemoryOperand());
       __ vmv_sx(dst, kScratchReg);
       break;
     }
@@ -1988,7 +1988,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     }
     case kRiscvS128Load64ExtendS: {
       __ VU.set(kScratchReg, E64, m1);
-      __ Ld(kScratchReg, i.MemoryOperand());
+      __ Lw(kScratchReg, i.MemoryOperand());
       __ vmv_vx(kSimd128ScratchReg, kScratchReg);
       __ VU.set(kScratchReg, i.InputInt8(2), m1);
       __ vsext_vf2(i.OutputSimd128Register(), kSimd128ScratchReg);
@@ -1996,7 +1996,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     }
     case kRiscvS128Load64ExtendU: {
       __ VU.set(kScratchReg, E64, m1);
-      __ Ld(kScratchReg, i.MemoryOperand());
+      __ Lw(kScratchReg, i.MemoryOperand());
       __ vmv_vx(kSimd128ScratchReg, kScratchReg);
       __ VU.set(kScratchReg, i.InputInt8(2), m1);
       __ vzext_vf2(i.OutputSimd128Register(), kSimd128ScratchReg);
@@ -2015,7 +2015,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
           __ Lw(kScratchReg, i.MemoryOperand());
           break;
         case E64:
-          __ Ld(kScratchReg, i.MemoryOperand());
+          __ Lw(kScratchReg, i.MemoryOperand());
           break;
         default:
           UNREACHABLE();
@@ -3917,11 +3917,11 @@ void CodeGenerator::AssembleConstructFrame() {
       // exception unconditionally. Thereby we can avoid the integer overflow
       // check in the condition code.
       if ((required_slots * kSystemPointerSize) < (FLAG_stack_size * 1024)) {
-        __ Ld(
+        __ Lw(
             kScratchReg,
             FieldMemOperand(kWasmInstanceRegister,
                             WasmInstanceObject::kRealStackLimitAddressOffset));
-        __ Ld(kScratchReg, MemOperand(kScratchReg));
+        __ Lw(kScratchReg, MemOperand(kScratchReg));
         __ Add(kScratchReg, kScratchReg,
                Operand(required_slots * kSystemPointerSize));
         __ BranchShort(&done, uge, sp, Operand(kScratchReg));
@@ -4027,7 +4027,7 @@ void CodeGenerator::AssembleReturn(InstructionOperand* additional_pop_count) {
     }
     if (drop_jsargs) {
       // Get the actual argument count
-      __ Ld(t0, MemOperand(fp, StandardFrameConstants::kArgCOffset));
+      __ Lw(t0, MemOperand(fp, StandardFrameConstants::kArgCOffset));
     }
     AssembleDeconstructFrame();
   }
@@ -4083,17 +4083,17 @@ void CodeGenerator::AssembleMove(InstructionOperand* source,
     if (destination->IsRegister()) {
       __ Move(g.ToRegister(destination), src);
     } else {
-      __ Sd(src, g.ToMemOperand(destination));
+      __ Sw(src, g.ToMemOperand(destination));
     }
   } else if (source->IsStackSlot()) {
     DCHECK(destination->IsRegister() || destination->IsStackSlot());
     MemOperand src = g.ToMemOperand(source);
     if (destination->IsRegister()) {
-      __ Ld(g.ToRegister(destination), src);
+      __ Lw(g.ToRegister(destination), src);
     } else {
       Register temp = kScratchReg;
-      __ Ld(temp, src);
-      __ Sd(temp, g.ToMemOperand(destination));
+      __ Lw(temp, src);
+      __ Sw(temp, g.ToMemOperand(destination));
     }
   } else if (source->IsConstant()) {
     Constant src = g.ToConstant(source);
@@ -4154,7 +4154,7 @@ void CodeGenerator::AssembleMove(InstructionOperand* source,
         case Constant::kRpoNumber:
           UNREACHABLE();  // TODO(titzer): loading RPO numbers
       }
-      if (destination->IsStackSlot()) __ Sd(dst, g.ToMemOperand(destination));
+      if (destination->IsStackSlot()) __ Sw(dst, g.ToMemOperand(destination));
     } else if (src.type() == Constant::kFloat32) {
       if (destination->IsFPStackSlot()) {
         MemOperand dst = g.ToMemOperand(destination);
@@ -4302,8 +4302,8 @@ void CodeGenerator::AssembleSwap(InstructionOperand* source,
         Register temp = kScratchReg;
         Register src = g.ToRegister(source);
         __ mv(temp, src);
-        __ Ld(src, dst);
-        __ Sd(temp, dst);
+        __ Lw(src, dst);
+        __ Sw(temp, dst);
       } else {
         MemOperand dst = g.ToMemOperand(destination);
         if (source->IsFloatRegister()) {
@@ -4358,10 +4358,10 @@ void CodeGenerator::AssembleSwap(InstructionOperand* source,
         UseScratchRegisterScope scope(tasm());
         Register temp_0 = kScratchReg;
         Register temp_1 = kScratchReg2;
-        __ Ld(temp_0, src);
-        __ Ld(temp_1, dst);
-        __ Sd(temp_0, dst);
-        __ Sd(temp_1, src);
+        __ Lw(temp_0, src);
+        __ Lw(temp_1, dst);
+        __ Sw(temp_0, dst);
+        __ Sw(temp_1, src);
       }
       return;
     }

--- a/src/regexp/riscv32/regexp-macro-assembler-riscv32.cc
+++ b/src/regexp/riscv32/regexp-macro-assembler-riscv32.cc
@@ -146,9 +146,9 @@ void RegExpMacroAssemblerRISCV::AdvanceRegister(int reg, int by) {
   DCHECK_LE(0, reg);
   DCHECK_GT(num_registers_, reg);
   if (by != 0) {
-    __ Ld(a0, register_location(reg));
+    __ Lw(a0, register_location(reg));
     __ Add(a0, a0, Operand(by));
-    __ Sd(a0, register_location(reg));
+    __ Sw(a0, register_location(reg));
   }
 }
 
@@ -156,9 +156,9 @@ void RegExpMacroAssemblerRISCV::Backtrack() {
   CheckPreemption();
   if (has_backtrack_limit()) {
     Label next;
-    __ Ld(a0, MemOperand(frame_pointer(), kBacktrackCount));
+    __ Lw(a0, MemOperand(frame_pointer(), kBacktrackCount));
     __ Add(a0, a0, Operand(1));
-    __ Sd(a0, MemOperand(frame_pointer(), kBacktrackCount));
+    __ Sw(a0, MemOperand(frame_pointer(), kBacktrackCount));
     __ BranchShort(&next, ne, a0, Operand(backtrack_limit()));
 
     // Backtrack limit exceeded.
@@ -190,7 +190,7 @@ void RegExpMacroAssemblerRISCV::CheckCharacterGT(base::uc16 limit,
 
 void RegExpMacroAssemblerRISCV::CheckAtStart(int cp_offset,
                                              Label* on_at_start) {
-  __ Ld(a1, MemOperand(frame_pointer(), kStringStartMinusOne));
+  __ Lw(a1, MemOperand(frame_pointer(), kStringStartMinusOne));
   __ Add(a0, current_input_offset(),
          Operand(-char_size() + cp_offset * char_size()));
   BranchOrBacktrack(on_at_start, eq, a0, Operand(a1));
@@ -198,7 +198,7 @@ void RegExpMacroAssemblerRISCV::CheckAtStart(int cp_offset,
 
 void RegExpMacroAssemblerRISCV::CheckNotAtStart(int cp_offset,
                                                 Label* on_not_at_start) {
-  __ Ld(a1, MemOperand(frame_pointer(), kStringStartMinusOne));
+  __ Lw(a1, MemOperand(frame_pointer(), kStringStartMinusOne));
   __ Add(a0, current_input_offset(),
          Operand(-char_size() + cp_offset * char_size()));
   BranchOrBacktrack(on_not_at_start, ne, a0, Operand(a1));
@@ -270,8 +270,8 @@ bool RegExpMacroAssemblerRISCV::CheckCharacterNotInRangeArray(
 void RegExpMacroAssemblerRISCV::CheckNotBackReferenceIgnoreCase(
     int start_reg, bool read_backward, bool unicode, Label* on_no_match) {
   Label fallthrough;
-  __ Ld(a0, register_location(start_reg));      // Index of start of capture.
-  __ Ld(a1, register_location(start_reg + 1));  // Index of end of capture.
+  __ Lw(a0, register_location(start_reg));      // Index of start of capture.
+  __ Lw(a1, register_location(start_reg + 1));  // Index of end of capture.
   __ Sub(a1, a1, a0);                           // Length of capture.
 
   // At this point, the capture registers are either both set or both cleared.
@@ -280,7 +280,7 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReferenceIgnoreCase(
   __ BranchShort(&fallthrough, eq, a1, Operand(zero_reg));
 
   if (read_backward) {
-    __ Ld(t1, MemOperand(frame_pointer(), kStringStartMinusOne));
+    __ Lw(t1, MemOperand(frame_pointer(), kStringStartMinusOne));
     __ Add(t1, t1, a1);
     BranchOrBacktrack(on_no_match, le, current_input_offset(), Operand(t1));
   } else {
@@ -340,8 +340,8 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReferenceIgnoreCase(
     // Compute new value of character position after the matched part.
     __ Sub(current_input_offset(), a2, end_of_input_address());
     if (read_backward) {
-      __ Ld(t1, register_location(start_reg));  // Index of start of capture.
-      __ Ld(a2, register_location(start_reg + 1));  // Index of end of capture.
+      __ Lw(t1, register_location(start_reg));  // Index of start of capture.
+      __ Lw(a2, register_location(start_reg + 1));  // Index of end of capture.
       __ Add(current_input_offset(), current_input_offset(), Operand(t1));
       __ Sub(current_input_offset(), current_input_offset(), Operand(a2));
     }
@@ -388,7 +388,7 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReferenceIgnoreCase(
     // Restore regexp engine registers.
     PopCallerSavedRegisters();
     __ li(code_pointer(), Operand(masm_->CodeObject()), CONSTANT_SIZE);
-    __ Ld(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
+    __ Lw(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
 
     // Check if function returned non-zero for success or zero for failure.
     BranchOrBacktrack(on_no_match, eq, a0, Operand(zero_reg));
@@ -409,8 +409,8 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReference(int start_reg,
   Label fallthrough;
 
   // Find length of back-referenced capture.
-  __ Ld(a0, register_location(start_reg));
-  __ Ld(a1, register_location(start_reg + 1));
+  __ Lw(a0, register_location(start_reg));
+  __ Lw(a1, register_location(start_reg + 1));
   __ Sub(a1, a1, a0);  // Length to check.
 
   // At this point, the capture registers are either both set or both cleared.
@@ -419,7 +419,7 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReference(int start_reg,
   __ BranchShort(&fallthrough, eq, a1, Operand(zero_reg));
 
   if (read_backward) {
-    __ Ld(t1, MemOperand(frame_pointer(), kStringStartMinusOne));
+    __ Lw(t1, MemOperand(frame_pointer(), kStringStartMinusOne));
     __ Add(t1, t1, a1);
     BranchOrBacktrack(on_no_match, le, current_input_offset(), Operand(t1));
   } else {
@@ -456,8 +456,8 @@ void RegExpMacroAssemblerRISCV::CheckNotBackReference(int start_reg,
   // Move current character position to position after match.
   __ Sub(current_input_offset(), a2, end_of_input_address());
   if (read_backward) {
-    __ Ld(t1, register_location(start_reg));      // Index of start of capture.
-    __ Ld(a2, register_location(start_reg + 1));  // Index of end of capture.
+    __ Lw(t1, register_location(start_reg));      // Index of start of capture.
+    __ Lw(a2, register_location(start_reg + 1));  // Index of end of capture.
     __ Add(current_input_offset(), current_input_offset(), Operand(t1));
     __ Sub(current_input_offset(), current_input_offset(), Operand(a2));
   }
@@ -636,7 +636,7 @@ void RegExpMacroAssemblerRISCV::LoadRegExpStackPointerFromMemory(Register dst) {
   ExternalReference ref =
       ExternalReference::address_of_regexp_stack_stack_pointer(isolate());
   __ li(dst, Operand(ref));
-  __ Ld(dst, MemOperand(dst));
+  __ Lw(dst, MemOperand(dst));
 }
 
 void RegExpMacroAssemblerRISCV::StoreRegExpStackPointerToMemory(
@@ -644,7 +644,7 @@ void RegExpMacroAssemblerRISCV::StoreRegExpStackPointerToMemory(
   ExternalReference ref =
       ExternalReference::address_of_regexp_stack_stack_pointer(isolate());
   __ li(scratch, Operand(ref));
-  __ Sd(src, MemOperand(scratch));
+  __ Sw(src, MemOperand(scratch));
 }
 
 void RegExpMacroAssemblerRISCV::PushRegExpBasePointer(Register scratch1,
@@ -653,18 +653,18 @@ void RegExpMacroAssemblerRISCV::PushRegExpBasePointer(Register scratch1,
   ExternalReference ref =
       ExternalReference::address_of_regexp_stack_memory_top_address(isolate());
   __ li(scratch2, Operand(ref));
-  __ Ld(scratch2, MemOperand(scratch2));
+  __ Lw(scratch2, MemOperand(scratch2));
   __ Sub(scratch2, scratch1, scratch2);
-  __ Sd(scratch2, MemOperand(frame_pointer(), kRegExpStackBasePointer));
+  __ Sw(scratch2, MemOperand(frame_pointer(), kRegExpStackBasePointer));
 }
 
 void RegExpMacroAssemblerRISCV::PopRegExpBasePointer(Register scratch1,
                                                      Register scratch2) {
   ExternalReference ref =
       ExternalReference::address_of_regexp_stack_memory_top_address(isolate());
-  __ Ld(scratch1, MemOperand(frame_pointer(), kRegExpStackBasePointer));
+  __ Lw(scratch1, MemOperand(frame_pointer(), kRegExpStackBasePointer));
   __ li(scratch2, ref);
-  __ Ld(scratch2, MemOperand(scratch2));
+  __ Lw(scratch2, MemOperand(scratch2));
   __ Add(scratch1, scratch1, scratch2);
   StoreRegExpStackPointerToMemory(scratch1, scratch2);
 }
@@ -744,7 +744,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
     ExternalReference stack_limit =
         ExternalReference::address_of_jslimit(masm_->isolate());
     __ li(a0, Operand(stack_limit));
-    __ Ld(a0, MemOperand(a0));
+    __ Lw(a0, MemOperand(a0));
     __ Sub(a0, sp, a0);
     // Handle it if the stack pointer is already below the stack limit.
     __ BranchShort(&stack_limit_hit, le, a0, Operand(zero_reg));
@@ -766,20 +766,20 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
     // Allocate space on stack for registers.
     __ Sub(sp, sp, Operand(num_registers_ * kSystemPointerSize));
     // Load string end.
-    __ Ld(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
+    __ Lw(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
     // Load input start.
-    __ Ld(a0, MemOperand(frame_pointer(), kInputStart));
+    __ Lw(a0, MemOperand(frame_pointer(), kInputStart));
     // Find negative length (offset of start relative to end).
     __ Sub(current_input_offset(), a0, end_of_input_address());
     // Set a0 to address of char before start of the input string
     // (effectively string position -1).
-    __ Ld(a1, MemOperand(frame_pointer(), kStartIndex));
+    __ Lw(a1, MemOperand(frame_pointer(), kStartIndex));
     __ Sub(a0, current_input_offset(), Operand(char_size()));
     __ slli(t1, a1, (mode_ == UC16) ? 1 : 0);
     __ Sub(a0, a0, t1);
     // Store this value in a local variable, for use when clearing
     // position registers.
-    __ Sd(a0, MemOperand(frame_pointer(), kStringStartMinusOne));
+    __ Sw(a0, MemOperand(frame_pointer(), kStringStartMinusOne));
 
     // Initialize code pointer register
     __ li(code_pointer(), Operand(masm_->CodeObject()), CONSTANT_SIZE);
@@ -805,13 +805,13 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
         __ li(a2, Operand(num_saved_registers_));
         Label init_loop;
         __ bind(&init_loop);
-        __ Sd(a0, MemOperand(a1));
+        __ Sw(a0, MemOperand(a1));
         __ Add(a1, a1, Operand(-kSystemPointerSize));
         __ Sub(a2, a2, Operand(1));
         __ Branch(&init_loop, ne, a2, Operand(zero_reg));
       } else {
         for (int i = 0; i < num_saved_registers_; i++) {
-          __ Sd(a0, register_location(i));
+          __ Sw(a0, register_location(i));
         }
       }
     }
@@ -827,9 +827,9 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
       __ bind(&success_label_);
       if (num_saved_registers_ > 0) {
         // Copy captures to output.
-        __ Ld(a1, MemOperand(frame_pointer(), kInputStart));
-        __ Ld(a0, MemOperand(frame_pointer(), kRegisterOutput));
-        __ Ld(a2, MemOperand(frame_pointer(), kStartIndex));
+        __ Lw(a1, MemOperand(frame_pointer(), kInputStart));
+        __ Lw(a0, MemOperand(frame_pointer(), kRegisterOutput));
+        __ Lw(a2, MemOperand(frame_pointer(), kStartIndex));
         __ Sub(a1, end_of_input_address(), a1);
         // a1 is length of input in bytes.
         if (mode_ == UC16) {
@@ -844,8 +844,8 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
         // unroll the loop once to add an operation between a load of a
         // register and the following use of that register.
         for (int i = 0; i < num_saved_registers_; i += 2) {
-          __ Ld(a2, register_location(i));
-          __ Ld(a3, register_location(i + 1));
+          __ Lw(a2, register_location(i));
+          __ Lw(a3, register_location(i + 1));
           if (i == 0 && global_with_zero_length_check()) {
             // Keep capture start in a4 for the zero-length check later.
             __ mv(s3, a2);
@@ -869,25 +869,25 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
 
       if (global()) {
         // Restart matching if the regular expression is flagged as global.
-        __ Ld(a0, MemOperand(frame_pointer(), kSuccessfulCaptures));
-        __ Ld(a1, MemOperand(frame_pointer(), kNumOutputRegisters));
-        __ Ld(a2, MemOperand(frame_pointer(), kRegisterOutput));
+        __ Lw(a0, MemOperand(frame_pointer(), kSuccessfulCaptures));
+        __ Lw(a1, MemOperand(frame_pointer(), kNumOutputRegisters));
+        __ Lw(a2, MemOperand(frame_pointer(), kRegisterOutput));
         // Increment success counter.
         __ Add(a0, a0, 1);
-        __ Sd(a0, MemOperand(frame_pointer(), kSuccessfulCaptures));
+        __ Sw(a0, MemOperand(frame_pointer(), kSuccessfulCaptures));
         // Capture results have been stored, so the number of remaining global
         // output registers is reduced by the number of stored captures.
         __ Sub(a1, a1, num_saved_registers_);
         // Check whether we have enough room for another set of capture results.
         __ Branch(&return_a0, lt, a1, Operand(num_saved_registers_));
 
-        __ Sd(a1, MemOperand(frame_pointer(), kNumOutputRegisters));
+        __ Sw(a1, MemOperand(frame_pointer(), kNumOutputRegisters));
         // Advance the location for output.
         __ Add(a2, a2, num_saved_registers_ * kIntSize);
-        __ Sd(a2, MemOperand(frame_pointer(), kRegisterOutput));
+        __ Sw(a2, MemOperand(frame_pointer(), kRegisterOutput));
 
         // Prepare a0 to initialize registers with its value in the next run.
-        __ Ld(a0, MemOperand(frame_pointer(), kStringStartMinusOne));
+        __ Lw(a0, MemOperand(frame_pointer(), kStringStartMinusOne));
 
         if (global_with_zero_length_check()) {
           // Special case for zero-length matches.
@@ -914,7 +914,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
     // Exit and return a0.
     __ bind(&exit_label_);
     if (global()) {
-      __ Ld(a0, MemOperand(frame_pointer(), kSuccessfulCaptures));
+      __ Lw(a0, MemOperand(frame_pointer(), kSuccessfulCaptures));
     }
 
     __ bind(&return_a0);
@@ -950,7 +950,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
       __ Branch(&return_a0, ne, a0, Operand(zero_reg));
       LoadRegExpStackPointerFromMemory(backtrack_stackpointer());
       // String might have moved: Reload end of string from frame.
-      __ Ld(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
+      __ Lw(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
       __ li(code_pointer(), Operand(masm_->CodeObject()), CONSTANT_SIZE);
       SafeReturn();
     }
@@ -973,7 +973,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
       __ mv(backtrack_stackpointer(), a0);
       // Restore saved registers and continue.
       __ li(code_pointer(), Operand(masm_->CodeObject()), CONSTANT_SIZE);
-      __ Ld(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
+      __ Lw(end_of_input_address(), MemOperand(frame_pointer(), kInputEnd));
       SafeReturn();
     }
 
@@ -1014,18 +1014,18 @@ void RegExpMacroAssemblerRISCV::GoTo(Label* to) {
 
 void RegExpMacroAssemblerRISCV::IfRegisterGE(int reg, int comparand,
                                              Label* if_ge) {
-  __ Ld(a0, register_location(reg));
+  __ Lw(a0, register_location(reg));
   BranchOrBacktrack(if_ge, ge, a0, Operand(comparand));
 }
 
 void RegExpMacroAssemblerRISCV::IfRegisterLT(int reg, int comparand,
                                              Label* if_lt) {
-  __ Ld(a0, register_location(reg));
+  __ Lw(a0, register_location(reg));
   BranchOrBacktrack(if_lt, lt, a0, Operand(comparand));
 }
 
 void RegExpMacroAssemblerRISCV::IfRegisterEqPos(int reg, Label* if_eq) {
-  __ Ld(a0, register_location(reg));
+  __ Lw(a0, register_location(reg));
   BranchOrBacktrack(if_eq, eq, a0, Operand(current_input_offset()));
 }
 
@@ -1040,7 +1040,7 @@ void RegExpMacroAssemblerRISCV::PopCurrentPosition() {
 
 void RegExpMacroAssemblerRISCV::PopRegister(int register_index) {
   Pop(a0);
-  __ Sd(a0, register_location(register_index));
+  __ Sw(a0, register_location(register_index));
 }
 
 void RegExpMacroAssemblerRISCV::PushBacktrack(Label* label) {
@@ -1073,20 +1073,20 @@ void RegExpMacroAssemblerRISCV::PushCurrentPosition() {
 
 void RegExpMacroAssemblerRISCV::PushRegister(int register_index,
                                              StackCheckFlag check_stack_limit) {
-  __ Ld(a0, register_location(register_index));
+  __ Lw(a0, register_location(register_index));
   Push(a0);
   if (check_stack_limit) CheckStackLimit();
 }
 
 void RegExpMacroAssemblerRISCV::ReadCurrentPositionFromRegister(int reg) {
-  __ Ld(current_input_offset(), register_location(reg));
+  __ Lw(current_input_offset(), register_location(reg));
 }
 
 void RegExpMacroAssemblerRISCV::WriteStackPointerToRegister(int reg) {
   ExternalReference ref =
       ExternalReference::address_of_regexp_stack_memory_top_address(isolate());
   __ li(a0, ref);
-  __ Ld(a0, MemOperand(a0));
+  __ Lw(a0, MemOperand(a0));
   __ Sub(a0, backtrack_stackpointer(), a0);
   __ Sw(a0, register_location(reg));
 }
@@ -1095,7 +1095,7 @@ void RegExpMacroAssemblerRISCV::ReadStackPointerFromRegister(int reg) {
   ExternalReference ref =
       ExternalReference::address_of_regexp_stack_memory_top_address(isolate());
   __ li(a1, ref);
-  __ Ld(a1, MemOperand(a1));
+  __ Lw(a1, MemOperand(a1));
   __ Lw(backtrack_stackpointer(), register_location(reg));
   __ Add(backtrack_stackpointer(), backtrack_stackpointer(), a1);
 }
@@ -1115,7 +1115,7 @@ void RegExpMacroAssemblerRISCV::SetCurrentPositionFromEnd(int by) {
 void RegExpMacroAssemblerRISCV::SetRegister(int register_index, int to) {
   DCHECK(register_index >= num_saved_registers_);  // Reserved for positions!
   __ li(a0, Operand(to));
-  __ Sd(a0, register_location(register_index));
+  __ Sw(a0, register_location(register_index));
 }
 
 bool RegExpMacroAssemblerRISCV::Succeed() {
@@ -1126,18 +1126,18 @@ bool RegExpMacroAssemblerRISCV::Succeed() {
 void RegExpMacroAssemblerRISCV::WriteCurrentPositionToRegister(int reg,
                                                                int cp_offset) {
   if (cp_offset == 0) {
-    __ Sd(current_input_offset(), register_location(reg));
+    __ Sw(current_input_offset(), register_location(reg));
   } else {
     __ Add(a0, current_input_offset(), Operand(cp_offset * char_size()));
-    __ Sd(a0, register_location(reg));
+    __ Sw(a0, register_location(reg));
   }
 }
 
 void RegExpMacroAssemblerRISCV::ClearRegisters(int reg_from, int reg_to) {
   DCHECK(reg_from <= reg_to);
-  __ Ld(a0, MemOperand(frame_pointer(), kStringStartMinusOne));
+  __ Lw(a0, MemOperand(frame_pointer(), kStringStartMinusOne));
   for (int reg = reg_from; reg <= reg_to; reg++) {
-    __ Sd(a0, register_location(reg));
+    __ Sw(a0, register_location(reg));
   }
 }
 #ifdef RISCV_HAS_NO_UNALIGNED
@@ -1156,7 +1156,7 @@ void RegExpMacroAssemblerRISCV::CallCheckStackGuardState(Register scratch) {
   __ Sub(sp, sp, Operand(kSystemPointerSize));
   DCHECK(base::bits::IsPowerOfTwo(stack_alignment));
   __ And(sp, sp, Operand(-stack_alignment));
-  __ Sd(scratch, MemOperand(sp));
+  __ Sw(scratch, MemOperand(sp));
 
   __ mv(a2, frame_pointer());
   // Code of self.
@@ -1200,7 +1200,7 @@ void RegExpMacroAssemblerRISCV::CallCheckStackGuardState(Register scratch) {
   // [sp + 2] - C argument slot.
   // [sp + 1] - C argument slot.
   // [sp + 0] - C argument slot.
-  __ Ld(sp, MemOperand(sp, stack_alignment + kCArgsSlotsSize));
+  __ Lw(sp, MemOperand(sp, stack_alignment + kCArgsSlotsSize));
 
   __ li(code_pointer(), Operand(masm_->CodeObject()));
 }
@@ -1246,7 +1246,7 @@ void RegExpMacroAssemblerRISCV::CheckPosition(int cp_offset,
     BranchOrBacktrack(on_outside_input, ge, current_input_offset(),
                       Operand(-cp_offset * char_size()));
   } else {
-    __ Ld(a1, MemOperand(frame_pointer(), kStringStartMinusOne));
+    __ Lw(a1, MemOperand(frame_pointer(), kStringStartMinusOne));
     __ Add(a0, current_input_offset(), Operand(cp_offset * char_size()));
     BranchOrBacktrack(on_outside_input, le, a0, Operand(a1));
   }
@@ -1306,7 +1306,7 @@ void RegExpMacroAssemblerRISCV::CheckPreemption() {
   ExternalReference stack_limit =
       ExternalReference::address_of_jslimit(masm_->isolate());
   __ li(a0, Operand(stack_limit));
-  __ Ld(a0, MemOperand(a0));
+  __ Lw(a0, MemOperand(a0));
   SafeCall(&check_preempt_label_, Uless_equal, sp, Operand(a0));
 }
 
@@ -1316,7 +1316,7 @@ void RegExpMacroAssemblerRISCV::CheckStackLimit() {
           masm_->isolate());
 
   __ li(a0, Operand(stack_limit));
-  __ Ld(a0, MemOperand(a0));
+  __ Lw(a0, MemOperand(a0));
   SafeCall(&stack_overflow_label_, Uless_equal, backtrack_stackpointer(),
            Operand(a0));
 }


### PR DESCRIPTION
Changed the Ld and Sd instructions in builtins-riscv32 and macro-assembler-riscv32 to Lw and Sw