### PR TITLE
Clean riscv64 code, port Ld to Lw

### DIFF
--- a/src/builtins/riscv32/builtins-riscv32.cc
+++ b/src/builtins/riscv32/builtins-riscv32.cc
@@ -2998,7 +2998,7 @@ void Builtins::Generate_DoubleToI(MacroAssembler* masm) {
   // Replace the shifted bits with bits from the lower mantissa word.
   Label pos_shift, shift_done, sign_negative;
   __ li(kScratchReg, 32);
-  __ subw(scratch, kScratchReg, scratch);
+  __ sub(scratch, kScratchReg, scratch);
   __ Branch(&pos_shift, ge, scratch, Operand(zero_reg), Label::Distance::kNear);
 
   // Negate scratch.
@@ -3007,7 +3007,7 @@ void Builtins::Generate_DoubleToI(MacroAssembler* masm) {
   __ BranchShort(&shift_done);
 
   __ bind(&pos_shift);
-  __ srlw(input_low, input_low, scratch);
+  __ srl(input_low, input_low, scratch);
 
   __ bind(&shift_done);
   __ Or(input_high, input_high, Operand(input_low));

--- a/src/codegen/riscv32/assembler-riscv32.h
+++ b/src/codegen/riscv32/assembler-riscv32.h
@@ -216,7 +216,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   int JumpOffset(Instr instr);
   int CJumpOffset(Instr instr);
   int CBranchOffset(Instr instr);
-  static int LdOffset(Instr instr);
+  static int LwOffset(Instr instr);
   static int AuipcOffset(Instr instr);
   static int JalrOffset(Instr instr);
 
@@ -471,20 +471,6 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   void csrrsi(Register rd, ControlStatusReg csr, uint8_t imm5);
   void csrrci(Register rd, ControlStatusReg csr, uint8_t imm5);
 
-  // RV64I
-  void lwu(Register rd, Register rs1, int16_t imm12);
-  void ld(Register rd, Register rs1, int16_t imm12);
-  void sd(Register source, Register base, int16_t imm12);
-  void addiw(Register rd, Register rs1, int16_t imm12);
-  void slliw(Register rd, Register rs1, uint8_t shamt);
-  void srliw(Register rd, Register rs1, uint8_t shamt);
-  void sraiw(Register rd, Register rs1, uint8_t shamt);
-  void addw(Register rd, Register rs1, Register rs2);
-  void subw(Register rd, Register rs1, Register rs2);
-  void sllw(Register rd, Register rs1, Register rs2);
-  void srlw(Register rd, Register rs1, Register rs2);
-  void sraw(Register rd, Register rs1, Register rs2);
-
   // RV32M Standard Extension
   void mul(Register rd, Register rs1, Register rs2);
   void mulh(Register rd, Register rs1, Register rs2);
@@ -652,8 +638,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   inline void c_bnez(Register rs1, Label* L) { c_bnez(rs1, branch_offset(L)); }
   void c_beqz(Register rs1, int16_t imm9);
   inline void c_beqz(Register rs1, Label* L) { c_beqz(rs1, branch_offset(L)); }
-  void c_srli(Register rs1, int8_t shamt6);
-  void c_srai(Register rs1, int8_t shamt6);
+  void c_srli(Register rs1, int8_t shamt5);
+  void c_srai(Register rs1, int8_t shamt5);
   void c_andi(Register rs1, int8_t imm6);
   void NOP();
   void EBREAK();
@@ -1062,9 +1048,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   void mv(Register rd, Register rs) { addi(rd, rs, 0); }
   void not_(Register rd, Register rs) { xori(rd, rs, -1); }
   void neg(Register rd, Register rs) { sub(rd, zero_reg, rs); }
-  void negw(Register rd, Register rs) { subw(rd, zero_reg, rs); }
-  void sext_w(Register rd, Register rs) { addiw(rd, rs, 0); }
   void seqz(Register rd, Register rs) { sltiu(rd, rs, 1); }
+  void sext_w(Register rd, Register rs) { addi(rd, rs, 0); }
   void snez(Register rd, Register rs) { sltu(rd, zero_reg, rs); }
   void sltz(Register rd, Register rs) { slt(rd, rs, zero_reg); }
   void sgtz(Register rd, Register rs) { slt(rd, zero_reg, rs); }
@@ -1277,11 +1262,10 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   static bool IsJalr(Instr instr);
   static bool IsLui(Instr instr);
   static bool IsAuipc(Instr instr);
-  static bool IsAddiw(Instr instr);
   static bool IsAddi(Instr instr);
   static bool IsOri(Instr instr);
   static bool IsSlli(Instr instr);
-  static bool IsLd(Instr instr);
+  static bool IsLw(Instr instr);
   void CheckTrampolinePool();
 
   // Get the code target object for a pc-relative call or jump.

--- a/src/codegen/riscv32/macro-assembler-riscv32.cc
+++ b/src/codegen/riscv32/macro-assembler-riscv32.cc
@@ -891,9 +891,9 @@ void TurboAssembler::Ror(Register rd, Register rs, const Operand& rt) {
   Register scratch = temps.Acquire();
   BlockTrampolinePoolScope block_trampoline_pool(this);
   if (rt.is_reg()) {
-    negw(scratch, rt.rm());
-    sllw(scratch, rs, scratch);
-    srlw(rd, rs, rt.rm());
+    neg(scratch, rt.rm());
+    sll(scratch, rs, scratch);
+    srl(rd, rs, rt.rm());
     or_(rd, scratch, rd);
     sext_w(rd, rd);
   } else {
@@ -904,8 +904,8 @@ void TurboAssembler::Ror(Register rd, Register rs, const Operand& rt) {
     } else if (ror_value < 0) {
       ror_value += 32;
     }
-    srliw(scratch, rs, ror_value);
-    slliw(rd, rs, 32 - ror_value);
+    srli(scratch, rs, ror_value);
+    slli(rd, rs, 32 - ror_value);
     or_(rd, scratch, rd);
     sext_w(rd, rd);
   }
@@ -916,7 +916,7 @@ void TurboAssembler::Dror(Register rd, Register rs, const Operand& rt) {
   Register scratch = temps.Acquire();
   BlockTrampolinePoolScope block_trampoline_pool(this);
   if (rt.is_reg()) {
-    negw(scratch, rt.rm());
+    neg(scratch, rt.rm());
     sll(scratch, rs, scratch);
     srl(rd, rs, rt.rm());
     or_(rd, scratch, rd);
@@ -1478,7 +1478,7 @@ void TurboAssembler::li(Register rd, Operand j, LiFlags mode) {
       RecordEntry((uint64_t)j.immediate(), j.rmode());
       auipc(rd, 0);
       // Record a value into constant pool.
-      ld(rd, rd, 0);
+      lw(rd, rd, 0);
     } else {
       if ((count - reverse_count) > 1) {
         Li(rd, ~j.immediate());
@@ -2393,30 +2393,30 @@ void TurboAssembler::Clz32(Register rd, Register xx) {
   DCHECK(xx != y && xx != n);
   Move(x, xx);
   li(n, Operand(32));
-  srliw(y, x, 16);
+  srli(y, x, 16);
   BranchShort(&L0, eq, y, Operand(zero_reg));
   Move(x, y);
-  addiw(n, n, -16);
+  addi(n, n, -16);
   bind(&L0);
-  srliw(y, x, 8);
+  srli(y, x, 8);
   BranchShort(&L1, eq, y, Operand(zero_reg));
-  addiw(n, n, -8);
+  addi(n, n, -8);
   Move(x, y);
   bind(&L1);
-  srliw(y, x, 4);
+  srli(y, x, 4);
   BranchShort(&L2, eq, y, Operand(zero_reg));
-  addiw(n, n, -4);
+  addi(n, n, -4);
   Move(x, y);
   bind(&L2);
-  srliw(y, x, 2);
+  srli(y, x, 2);
   BranchShort(&L3, eq, y, Operand(zero_reg));
-  addiw(n, n, -2);
+  addi(n, n, -2);
   Move(x, y);
   bind(&L3);
-  srliw(y, x, 1);
-  subw(rd, n, x);
+  srli(y, x, 1);
+  sub(rd, n, x);
   BranchShort(&L4, eq, y, Operand(zero_reg));
-  addiw(rd, n, -2);
+  addi(rd, n, -2);
   bind(&L4);
 }
 
@@ -2485,7 +2485,7 @@ void TurboAssembler::Popcnt32(Register rd, Register rs, Register scratch) {
   Srl32(scratch, scratch, 2);
   And(scratch, scratch, scratch2);
   Add(scratch, rd, scratch);
-  srliw(rd, scratch, 4);
+  srli(rd, scratch, 4);
   Add(rd, rd, scratch);
   li(scratch2, 0xF);
   Mul32(scratch2, value, scratch2);  // B2 = 0x0F0F0F0F;
@@ -2524,7 +2524,7 @@ void TurboAssembler::TruncateDoubleToI(Isolate* isolate, Zone* zone,
   } else {
     Call(BUILTIN_CODE(isolate, DoubleToI), RelocInfo::CODE_TARGET);
   }
-  ld(result, sp, 0);
+  lw(result, sp, 0);
 
   Add(sp, sp, Operand(kDoubleSize));
   pop(ra);
@@ -3916,7 +3916,7 @@ void MacroAssembler::JumpToOffHeapInstructionStream(Address entry) {
     RecordEntry(entry, RelocInfo::OFF_HEAP_TARGET);
     RecordRelocInfo(RelocInfo::OFF_HEAP_TARGET, entry);
     auipc(kOffHeapTrampolineRegister, 0);
-    ld(kOffHeapTrampolineRegister, kOffHeapTrampolineRegister, 0);
+    lw(kOffHeapTrampolineRegister, kOffHeapTrampolineRegister, 0);
   }
   Jump(kOffHeapTrampolineRegister);
 }

--- a/src/codegen/riscv32/macro-assembler-riscv32.h
+++ b/src/codegen/riscv32/macro-assembler-riscv32.h
@@ -476,7 +476,8 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   void SmiUntag(Register dst, Register src) {
     DCHECK(SmiValuesAre32Bits() || SmiValuesAre31Bits());
     if (COMPRESS_POINTERS_BOOL) {
-      sraiw(dst, src, kSmiShift);
+      // TODO: use c_srai?
+      srai(dst, src, kSmiShift);
     } else {
       srai(dst, src, kSmiShift);
     }

--- a/src/compiler/backend/riscv32/code-generator-riscv32.cc
+++ b/src/compiler/backend/riscv32/code-generator-riscv32.cc
@@ -1576,23 +1576,11 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvUlw:
       __ Ulw(i.OutputRegister(), i.MemoryOperand());
       break;
-    case kRiscvUlwu:
-      __ Ulwu(i.OutputRegister(), i.MemoryOperand());
-      break;
-    case kRiscvLd:
-      __ Lw(i.OutputRegister(), i.MemoryOperand());
-      break;
-    case kRiscvUld:
-      __ Uld(i.OutputRegister(), i.MemoryOperand());
-      break;
     case kRiscvSw:
       __ Sw(i.InputOrZeroRegister(2), i.MemoryOperand());
       break;
     case kRiscvUsw:
       __ Usw(i.InputOrZeroRegister(2), i.MemoryOperand());
-      break;
-    case kRiscvSd:
-      __ Sw(i.InputOrZeroRegister(2), i.MemoryOperand());
       break;
     case kRiscvUsd:
       __ Usd(i.InputOrZeroRegister(2), i.MemoryOperand());
@@ -1923,7 +1911,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
     case kRiscvS128Load32Zero: {
       Simd128Register dst = i.OutputSimd128Register();
       __ VU.set(kScratchReg, E32, m1);
-      __ Lwu(kScratchReg, i.MemoryOperand());
+      __ Lw(kScratchReg, i.MemoryOperand());
       __ vmv_sx(dst, kScratchReg);
       break;
     }

--- a/src/compiler/backend/riscv32/instruction-codes-riscv32.h
+++ b/src/compiler/backend/riscv32/instruction-codes-riscv32.h
@@ -117,7 +117,6 @@ namespace compiler {
   V(RiscvUlhu)                              \
   V(RiscvSh)                                \
   V(RiscvUsh)                               \
-  V(RiscvLd)                                \
   V(RiscvUld)                               \
   V(RiscvLw)                                \
   V(RiscvUlw)                               \

--- a/src/compiler/backend/riscv32/instruction-scheduler-riscv32.cc
+++ b/src/compiler/backend/riscv32/instruction-scheduler-riscv32.cc
@@ -351,7 +351,6 @@ int InstructionScheduler::GetTargetInstructionFlags(
 
     case kRiscvLb:
     case kRiscvLbu:
-    case kRiscvLd:
     case kRiscvLoadDouble:
     case kRiscvLh:
     case kRiscvLhu:
@@ -1411,7 +1410,6 @@ int InstructionScheduler::GetInstructionLatency(const Instruction* instr) {
     case kRiscvLh:
     case kRiscvLwu:
     case kRiscvLw:
-    case kRiscvLd:
     case kRiscvSb:
     case kRiscvSh:
     case kRiscvSw:

--- a/src/compiler/backend/riscv32/instruction-selector-riscv32.cc
+++ b/src/compiler/backend/riscv32/instruction-selector-riscv32.cc
@@ -104,7 +104,6 @@ class RiscvOperandGenerator final : public OperandGenerator {
       case kRiscvSh:
       case kRiscvLw:
       case kRiscvSw:
-      case kRiscvLd:
       case kRiscvSd:
       case kRiscvLoadFloat:
       case kRiscvStoreFloat:

--- a/src/diagnostics/riscv32/disasm-riscv32.cc
+++ b/src/diagnostics/riscv32/disasm-riscv32.cc
@@ -910,26 +910,6 @@ void Decoder::DecodeRType(Instruction* instr) {
     case RO_AND:
       Format(instr, "and       'rd, 'rs1, 'rs2");
       break;
-#ifdef V8_TARGET_ARCH_64_BIT
-    case RO_ADDW:
-      Format(instr, "addw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_SUBW:
-      if (instr->Rs1Value() == zero_reg.code())
-        Format(instr, "negw      'rd, 'rs2");
-      else
-        Format(instr, "subw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_SLLW:
-      Format(instr, "sllw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_SRLW:
-      Format(instr, "srlw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_SRAW:
-      Format(instr, "sraw      'rd, 'rs1, 'rs2");
-      break;
-#endif /* V8_TARGET_ARCH_64_BIT */
     // TODO(riscv): Add RISCV M extension macro
     case RO_MUL:
       Format(instr, "mul       'rd, 'rs1, 'rs2");
@@ -955,23 +935,6 @@ void Decoder::DecodeRType(Instruction* instr) {
     case RO_REMU:
       Format(instr, "remu      'rd, 'rs1, 'rs2");
       break;
-#ifdef V8_TARGET_ARCH_64_BIT
-    case RO_MULW:
-      Format(instr, "mulw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_DIVW:
-      Format(instr, "divw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_DIVUW:
-      Format(instr, "divuw     'rd, 'rs1, 'rs2");
-      break;
-    case RO_REMW:
-      Format(instr, "remw      'rd, 'rs1, 'rs2");
-      break;
-    case RO_REMUW:
-      Format(instr, "remuw     'rd, 'rs1, 'rs2");
-      break;
-#endif /*V8_TARGET_ARCH_64_BIT*/
     // TODO(riscv): End Add RISCV M extension macro
     default: {
       switch (instr->BaseOpcode()) {
@@ -1444,14 +1407,6 @@ void Decoder::DecodeIType(Instruction* instr) {
       case RO_LHU:
         Format(instr, "lhu       'rd, 'imm12('rs1)");
         break;
-#ifdef V8_TARGET_ARCH_64_BIT
-      case RO_LWU:
-        Format(instr, "lwu       'rd, 'imm12('rs1)");
-        break;
-      case RO_LD:
-        Format(instr, "ld        'rd, 'imm12('rs1)");
-        break;
-#endif /*V8_TARGET_ARCH_64_BIT*/
       case RO_ADDI:
         if (instr->Imm12Value() == 0) {
           if (instr->RdValue() == zero_reg.code() &&
@@ -1497,25 +1452,6 @@ void Decoder::DecodeIType(Instruction* instr) {
         }
         break;
       }
-#ifdef V8_TARGET_ARCH_64_BIT
-      case RO_ADDIW:
-        if (instr->Imm12Value() == 0)
-          Format(instr, "sext.w    'rd, 'rs1");
-        else
-          Format(instr, "addiw     'rd, 'rs1, 'imm12");
-        break;
-      case RO_SLLIW:
-        Format(instr, "slliw     'rd, 'rs1, 's32");
-        break;
-      case RO_SRLIW: {  //  RO_SRAIW
-        if (!instr->IsArithShift()) {
-          Format(instr, "srliw     'rd, 'rs1, 's32");
-        } else {
-          Format(instr, "sraiw     'rd, 'rs1, 's32");
-        }
-        break;
-      }
-#endif /*V8_TARGET_ARCH_64_BIT*/
       case RO_FENCE:
         if (instr->MemoryOrder(true) == PSIORW &&
             instr->MemoryOrder(false) == PSIORW)
@@ -1654,11 +1590,6 @@ void Decoder::DecodeSType(Instruction* instr) {
       case RO_SW:
         Format(instr, "sw        'rs2, 'offS('rs1)");
         break;
-#ifdef V8_TARGET_ARCH_64_BIT
-      case RO_SD:
-        Format(instr, "sd        'rs2, 'offS('rs1)");
-        break;
-#endif /*V8_TARGET_ARCH_64_BIT*/
       // TODO(riscv): use F Extension macro block
       case RO_FSW:
         Format(instr, "fsw       'fs2, 'offS('rs1)");

--- a/src/wasm/jump-table-assembler.cc
+++ b/src/wasm/jump-table-assembler.cc
@@ -368,7 +368,7 @@ void JumpTableAssembler::NopBytes(int bytes) {
   }
 }
 
-#elif V8_TARGET_ARCH_RISCV64 || V8_TARGET_ARCH_RISCV32
+#elif V8_TARGET_ARCH_RISCV64
 void JumpTableAssembler::EmitLazyCompileJumpSlot(uint32_t func_index,
                                                  Address lazy_compile_target) {
   int start = pc_offset();
@@ -390,6 +390,46 @@ void JumpTableAssembler::EmitFarJumpSlot(Address target) {
   Register rd = temp.Acquire();
   auipc(rd, 0);
   ld(rd, rd, 4 * kInstrSize);
+  Jump(rd);
+  nop();
+  dq(target);
+}
+
+// static
+void JumpTableAssembler::PatchFarJumpSlot(Address slot, Address target) {
+  UNREACHABLE();
+}
+
+void JumpTableAssembler::NopBytes(int bytes) {
+  DCHECK_LE(0, bytes);
+  DCHECK_EQ(0, bytes % kInstrSize);
+  for (; bytes > 0; bytes -= kInstrSize) {
+    nop();
+  }
+}
+
+#elif V8_TARGET_ARCH_RISCV32
+void JumpTableAssembler::EmitLazyCompileJumpSlot(uint32_t func_index,
+                                                 Address lazy_compile_target) {
+  int start = pc_offset();
+  li(kWasmCompileLazyFuncIndexRegister, func_index);  // max. 2 instr
+  // Jump produces max. 8 instructions (include constant pool and j)
+  Jump(lazy_compile_target, RelocInfo::NO_INFO);
+  int nop_bytes = start + kLazyCompileTableSlotSize - pc_offset();
+  DCHECK_EQ(nop_bytes % kInstrSize, 0);
+  for (int i = 0; i < nop_bytes; i += kInstrSize) nop();
+}
+
+bool JumpTableAssembler::EmitJumpSlot(Address target) {
+  PatchAndJump(target);
+  return true;
+}
+
+void JumpTableAssembler::EmitFarJumpSlot(Address target) {
+  UseScratchRegisterScope temp(this);
+  Register rd = temp.Acquire();
+  auipc(rd, 0);
+  lw(rd, rd, 4 * kInstrSize);
   Jump(rd);
   nop();
   dq(target);

--- a/test/cctest/test-disasm-riscv32.cc
+++ b/test/cctest/test-disasm-riscv32.cc
@@ -208,25 +208,6 @@ TEST(CSR) {
   VERIFY_RUN();
 }
 
-TEST(RV64I) {
-  SET_UP();
-
-  COMPARE(lwu(a0, s3, -268), "ef49e503       lwu       a0, -268(s3)");
-  COMPARE(ld(a1, s3, -268), "ef49b583       ld        a1, -268(s3)");
-  COMPARE(sd(fp, sp, -268), "ee813a23       sd        fp, -268(sp)");
-  COMPARE(addiw(gp, s3, -268), "ef49819b       addiw     gp, s3, -268");
-  COMPARE(slliw(tp, s3, 17), "0119921b       slliw     tp, s3, 17");
-  COMPARE(srliw(ra, s3, 10), "00a9d09b       srliw     ra, s3, 10");
-  COMPARE(sraiw(sp, s3, 17), "4119d11b       sraiw     sp, s3, 17");
-  COMPARE(addw(t1, zero_reg, s4), "0140033b       addw      t1, zero_reg, s4");
-  COMPARE(subw(t2, s3, s4), "414983bb       subw      t2, s3, s4");
-  COMPARE(sllw(s7, s3, s4), "01499bbb       sllw      s7, s3, s4");
-  COMPARE(srlw(s10, s3, s4), "0149dd3b       srlw      s10, s3, s4");
-  COMPARE(sraw(a7, s3, s4), "4149d8bb       sraw      a7, s3, s4");
-
-  VERIFY_RUN();
-}
-
 TEST(RV32M) {
   SET_UP();
 
@@ -238,18 +219,6 @@ TEST(RV32M) {
   COMPARE(divu(a0, s3, t4), "03d9d533       divu      a0, s3, t4");
   COMPARE(rem(a0, s3, t4), "03d9e533       rem       a0, s3, t4");
   COMPARE(remu(a0, s3, t4), "03d9f533       remu      a0, s3, t4");
-
-  VERIFY_RUN();
-}
-
-TEST(RV64M) {
-  SET_UP();
-
-  COMPARE(mulw(a0, s3, s4), "0349853b       mulw      a0, s3, s4");
-  COMPARE(divw(a0, s3, s4), "0349c53b       divw      a0, s3, s4");
-  COMPARE(divuw(a0, s3, s4), "0349d53b       divuw     a0, s3, s4");
-  COMPARE(remw(a0, s3, s4), "0349e53b       remw      a0, s3, s4");
-  COMPARE(remuw(a0, s3, s4), "0349f53b       remuw     a0, s3, s4");
 
   VERIFY_RUN();
 }
@@ -411,7 +380,6 @@ TEST(PSEUDO) {
   COMPARE(mv(t0, a4), "00070293       mv        t0, a4");
   COMPARE(not_(t0, a5), "fff7c293       not       t0, a5");
   COMPARE(neg(ra, a6), "410000b3       neg       ra, a6");
-  COMPARE(negw(t2, fp), "408003bb       negw      t2, fp");
   COMPARE(sext_w(t0, s1), "0004829b       sext.w    t0, s1");
   COMPARE(seqz(sp, s2), "00193113       seqz      sp, s2");
   COMPARE(snez(fp, s3), "01303433       snez      fp, s3");

--- a/test/cctest/test-helper-riscv32.h
+++ b/test/cctest/test-helper-riscv32.h
@@ -232,7 +232,7 @@ void GenAndRunTestForLRSC(T value, Func test_generator) {
   if (std::is_same<int32_t, T>::value) {
     assm.sw(a1, a0, 0);
   } else if (std::is_same<int64_t, T>::value) {
-    assm.sd(a1, a0, 0);
+    UNREACHABLE();
   }
   test_generator(assm);
 
@@ -284,7 +284,7 @@ OUTPUT_T GenAndRunTestForAMO(INPUT_T input0, INPUT_T input1,
     assm.sw(a1, a0, 0);
   } else if (std::is_same<int64_t, INPUT_T>::value ||
              std::is_same<uint64_t, INPUT_T>::value) {
-    assm.sd(a1, a0, 0);
+    UNREACHABLE();
   }
   test_generator(assm);
 
@@ -301,7 +301,7 @@ OUTPUT_T GenAndRunTestForAMO(INPUT_T input0, INPUT_T input1,
     assm.lw(a0, a0, 0);
   } else if (std::is_same<int64_t, INPUT_T>::value ||
              std::is_same<uint64_t, INPUT_T>::value) {
-    assm.ld(a0, a0, 0);
+    UNREACHABLE();
   }
 
   assm.jr(ra);

--- a/test/unittests/compiler/riscv32/instruction-selector-riscv32-unittest.cc
+++ b/test/unittests/compiler/riscv32/instruction-selector-riscv32-unittest.cc
@@ -1009,7 +1009,7 @@ static const MemoryAccess kMemoryAccesses[] = {
     {MachineType::Int32(), kRiscvLw, kRiscvSw},
     {MachineType::Float32(), kRiscvLoadFloat, kRiscvStoreFloat},
     {MachineType::Float64(), kRiscvLoadDouble, kRiscvStoreDouble},
-    {MachineType::Int64(), kRiscvLd, kRiscvSd}};
+    {MachineType::Int64(), kRiscvLw, kRiscvSd}};
 
 struct MemoryAccessImm {
   MachineType type;
@@ -1099,7 +1099,7 @@ const MemoryAccessImm kMemoryAccessesImm[] = {
       39,    52,    69,    71,    91,    92,    107,   109,  115,  124,
       286,   655,   1362,  1569,  2587,  3067,  3096,  3462, 3510, 4095}},
     {MachineType::Int64(),
-     kRiscvLd,
+     kRiscvLw,
      kRiscvSd,
      &InstructionSelectorTest::Stream::IsInteger,
      {-4095, -3340, -3231, -3224, -3088, -1758, -1203, -123, -117, -91,
@@ -1144,7 +1144,7 @@ const MemoryAccessImm1 kMemoryAccessImmMoreThan16bit[] = {
      &InstructionSelectorTest::Stream::IsDouble,
      {-65000, -55000, 32777, 55000, 65000}},
     {MachineType::Int64(),
-     kRiscvLd,
+     kRiscvLw,
      kRiscvSd,
      &InstructionSelectorTest::Stream::IsInteger,
      {-65000, -55000, 32777, 55000, 65000}}};
@@ -1572,7 +1572,7 @@ TEST_F(InstructionSelectorTest, ExternalReferenceLoad1) {
     Stream s = m.Build();
 
     ASSERT_EQ(1U, s.size());
-    EXPECT_EQ(kRiscvLd, s[0]->arch_opcode());
+    EXPECT_EQ(kRiscvLw, s[0]->arch_opcode());
     EXPECT_EQ(kMode_Root, s[0]->addressing_mode());
     EXPECT_EQ(1U, s[0]->InputCount());
     EXPECT_EQ(s.ToInt64(s[0]->InputAt(0)), offset);
@@ -1584,7 +1584,7 @@ TEST_F(InstructionSelectorTest, ExternalReferenceLoad2) {
   // Offset too large, we cannot use kMode_Root.
   StreamBuilder m(this, MachineType::Int64());
   // RV32Gtodo re-impl offset
-  int32_t offset = 0x10000000;
+  int32_t offset = 0x1000000;
   ExternalReference reference =
       bit_cast<ExternalReference>(int32_t(isolate()->isolate_root() + offset));
   Node* const value =
@@ -1594,7 +1594,7 @@ TEST_F(InstructionSelectorTest, ExternalReferenceLoad2) {
   Stream s = m.Build();
 
   ASSERT_EQ(1U, s.size());
-  EXPECT_EQ(kRiscvLd, s[0]->arch_opcode());
+  EXPECT_EQ(kRiscvLw, s[0]->arch_opcode());
   EXPECT_NE(kMode_Root, s[0]->addressing_mode());
 }
 


### PR DESCRIPTION
I have cleaned some riscv64 code and port `Ld` related code (`IsLd`, `LdOffset`) to `Lw` (`IsLw`, `LwOffset`). There is still a debug check fail: line 4009 `DCHECK(assm_->IsLw(instr_lw))` in `src/codegen/riscv32/assembler-riscv32.cc` so it's WIP.

If you find something that could be improved, please let me know! Thanks!