### PR TITLE
changed 32/64 suffix from m instructions

### DIFF
--- a/src/codegen/riscv32/macro-assembler-riscv32.cc
+++ b/src/codegen/riscv32/macro-assembler-riscv32.cc
@@ -450,7 +450,7 @@ void TurboAssembler::Mulh(Register rd, Register rs, const Operand& rt) {
 }
 
 void TurboAssembler::Mulhu(Register rd, Register rs, const Operand& rt,
-                             Register rsz, Register rtz) {
+                           Register rsz, Register rtz) {
   if (rt.is_reg()) {
     mulhu(rd, rs, rt.rm());
   } else {

--- a/src/codegen/riscv32/macro-assembler-riscv32.cc
+++ b/src/codegen/riscv32/macro-assembler-riscv32.cc
@@ -425,7 +425,7 @@ void TurboAssembler::Sub(Register rd, Register rs, const Operand& rt) {
   }
 }
 
-void TurboAssembler::Mul32(Register rd, Register rs, const Operand& rt) {
+void TurboAssembler::Mul(Register rd, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
     mul(rd, rs, rt.rm());
   } else {
@@ -437,7 +437,7 @@ void TurboAssembler::Mul32(Register rd, Register rs, const Operand& rt) {
   }
 }
 
-void TurboAssembler::Mulh32(Register rd, Register rs, const Operand& rt) {
+void TurboAssembler::Mulh(Register rd, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
     mulh(rd, rs, rt.rm());
   } else {
@@ -449,7 +449,7 @@ void TurboAssembler::Mulh32(Register rd, Register rs, const Operand& rt) {
   }
 }
 
-void TurboAssembler::Mulhu32(Register rd, Register rs, const Operand& rt,
+void TurboAssembler::Mulhu(Register rd, Register rs, const Operand& rt,
                              Register rsz, Register rtz) {
   if (rt.is_reg()) {
     mulhu(rd, rs, rt.rm());
@@ -462,31 +462,7 @@ void TurboAssembler::Mulhu32(Register rd, Register rs, const Operand& rt,
   }
 }
 
-void TurboAssembler::Mul64(Register rd, Register rs, const Operand& rt) {
-  if (rt.is_reg()) {
-    mul(rd, rs, rt.rm());
-  } else {
-    // li handles the relocation.
-    UseScratchRegisterScope temps(this);
-    Register scratch = temps.Acquire();
-    Li(scratch, rt.immediate());
-    mul(rd, rs, scratch);
-  }
-}
-
-void TurboAssembler::Mulh64(Register rd, Register rs, const Operand& rt) {
-  if (rt.is_reg()) {
-    mulh(rd, rs, rt.rm());
-  } else {
-    // li handles the relocation.
-    UseScratchRegisterScope temps(this);
-    Register scratch = temps.Acquire();
-    Li(scratch, rt.immediate());
-    mulh(rd, rs, scratch);
-  }
-}
-
-void TurboAssembler::Div32(Register res, Register rs, const Operand& rt) {
+void TurboAssembler::Div(Register res, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
     div(res, rs, rt.rm());
   } else {
@@ -498,7 +474,7 @@ void TurboAssembler::Div32(Register res, Register rs, const Operand& rt) {
   }
 }
 
-void TurboAssembler::Mod32(Register rd, Register rs, const Operand& rt) {
+void TurboAssembler::Mod(Register rd, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
     rem(rd, rs, rt.rm());
   } else {
@@ -510,7 +486,7 @@ void TurboAssembler::Mod32(Register rd, Register rs, const Operand& rt) {
   }
 }
 
-void TurboAssembler::Modu32(Register rd, Register rs, const Operand& rt) {
+void TurboAssembler::Modu(Register rd, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
     remu(rd, rs, rt.rm());
   } else {
@@ -522,19 +498,7 @@ void TurboAssembler::Modu32(Register rd, Register rs, const Operand& rt) {
   }
 }
 
-void TurboAssembler::Div64(Register rd, Register rs, const Operand& rt) {
-  if (rt.is_reg()) {
-    div(rd, rs, rt.rm());
-  } else {
-    // li handles the relocation.
-    UseScratchRegisterScope temps(this);
-    Register scratch = temps.Acquire();
-    Li(scratch, rt.immediate());
-    div(rd, rs, scratch);
-  }
-}
-
-void TurboAssembler::Divu32(Register res, Register rs, const Operand& rt) {
+void TurboAssembler::Divu(Register res, Register rs, const Operand& rt) {
   if (rt.is_reg()) {
     divu(res, rs, rt.rm());
   } else {
@@ -543,42 +507,6 @@ void TurboAssembler::Divu32(Register res, Register rs, const Operand& rt) {
     Register scratch = temps.Acquire();
     Li(scratch, rt.immediate());
     divu(res, rs, scratch);
-  }
-}
-
-void TurboAssembler::Divu64(Register res, Register rs, const Operand& rt) {
-  if (rt.is_reg()) {
-    divu(res, rs, rt.rm());
-  } else {
-    // li handles the relocation.
-    UseScratchRegisterScope temps(this);
-    Register scratch = temps.Acquire();
-    Li(scratch, rt.immediate());
-    divu(res, rs, scratch);
-  }
-}
-
-void TurboAssembler::Mod64(Register rd, Register rs, const Operand& rt) {
-  if (rt.is_reg()) {
-    rem(rd, rs, rt.rm());
-  } else {
-    // li handles the relocation.
-    UseScratchRegisterScope temps(this);
-    Register scratch = temps.Acquire();
-    Li(scratch, rt.immediate());
-    rem(rd, rs, scratch);
-  }
-}
-
-void TurboAssembler::Modu64(Register rd, Register rs, const Operand& rt) {
-  if (rt.is_reg()) {
-    remu(rd, rs, rt.rm());
-  } else {
-    // li handles the relocation.
-    UseScratchRegisterScope temps(this);
-    Register scratch = temps.Acquire();
-    Li(scratch, rt.immediate());
-    remu(rd, rs, scratch);
   }
 }
 
@@ -2452,9 +2380,9 @@ void TurboAssembler::Popcnt32(Register rd, Register rs, Register scratch) {
   srli(rd, scratch, 4);
   Add(rd, rd, scratch);
   li(scratch2, 0xF);
-  Mul32(scratch2, value, scratch2);  // B2 = 0x0F0F0F0F;
+  Mul(scratch2, value, scratch2);  // B2 = 0x0F0F0F0F;
   And(rd, rd, scratch2);
-  Mul32(rd, rd, value);
+  Mul(rd, rd, value);
   Srl32(rd, rd, shift);
 }
 

--- a/src/codegen/riscv32/macro-assembler-riscv32.h
+++ b/src/codegen/riscv32/macro-assembler-riscv32.h
@@ -723,7 +723,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
 
   // MIPS-style 32-bit unsigned mulh
   void Mulhu(Register dst, Register left, const Operand& right,
-               Register left_zero, Register right_zero);
+             Register left_zero, Register right_zero);
 
   // Number of instructions needed for calculation of switch table entry address
   static const int kSwitchTablePrologueSize = 6;

--- a/src/codegen/riscv32/macro-assembler-riscv32.h
+++ b/src/codegen/riscv32/macro-assembler-riscv32.h
@@ -417,23 +417,15 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
 #define DEFINE_INSTRUCTION3(instr) void instr(Register rd, int32_t imm);
 
   DEFINE_INSTRUCTION(Add)
-  DEFINE_INSTRUCTION(Div32)
-  DEFINE_INSTRUCTION(Divu32)
-  DEFINE_INSTRUCTION(Divu64)
-  DEFINE_INSTRUCTION(Mod32)
-  DEFINE_INSTRUCTION(Modu32)
-  DEFINE_INSTRUCTION(Div64)
+  DEFINE_INSTRUCTION(Div)
+  DEFINE_INSTRUCTION(Divu)
+  DEFINE_INSTRUCTION(Mod)
+  DEFINE_INSTRUCTION(Modu)
   DEFINE_INSTRUCTION(Sub)
-  DEFINE_INSTRUCTION(Mod64)
-  DEFINE_INSTRUCTION(Modu64)
-  DEFINE_INSTRUCTION(Mul32)
-  DEFINE_INSTRUCTION(Mulh32)
-  DEFINE_INSTRUCTION(Mul64)
-  DEFINE_INSTRUCTION(Mulh64)
-  DEFINE_INSTRUCTION2(Div32)
-  DEFINE_INSTRUCTION2(Div64)
-  DEFINE_INSTRUCTION2(Divu32)
-  DEFINE_INSTRUCTION2(Divu64)
+  DEFINE_INSTRUCTION(Mul)
+  DEFINE_INSTRUCTION(Mulh)
+  DEFINE_INSTRUCTION2(Div)
+  DEFINE_INSTRUCTION2(Divu)
 
   DEFINE_INSTRUCTION(And)
   DEFINE_INSTRUCTION(Or)
@@ -730,7 +722,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
                      Register overflow);
 
   // MIPS-style 32-bit unsigned mulh
-  void Mulhu32(Register dst, Register left, const Operand& right,
+  void Mulhu(Register dst, Register left, const Operand& right,
                Register left_zero, Register right_zero);
 
   // Number of instructions needed for calculation of switch table entry address

--- a/src/compiler/backend/riscv32/code-generator-riscv32.cc
+++ b/src/compiler/backend/riscv32/code-generator-riscv32.cc
@@ -993,12 +993,11 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
                        i.InputOperand(1), kScratchReg);
       break;
     case kRiscvMulHigh32:
-      __ Mulh(i.OutputRegister(), i.InputOrZeroRegister(0),
-                i.InputOperand(1));
+      __ Mulh(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       break;
     case kRiscvMulHighU32:
-      __ Mulhu(i.OutputRegister(), i.InputOrZeroRegister(0),
-                 i.InputOperand(1), kScratchReg, kScratchReg2);
+      __ Mulhu(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1),
+               kScratchReg, kScratchReg2);
       break;
     case kRiscvDiv32: {
       __ Div(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
@@ -1007,8 +1006,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       break;
     }
     case kRiscvDivU32: {
-      __ Divu(i.OutputRegister(), i.InputOrZeroRegister(0),
-                i.InputOperand(1));
+      __ Divu(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       // Set ouput to zero if divisor == 0
       __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
@@ -1017,8 +1015,7 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       __ Mod(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       break;
     case kRiscvModU32:
-      __ Modu(i.OutputRegister(), i.InputOrZeroRegister(0),
-                i.InputOperand(1));
+      __ Modu(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       break;
     case kRiscvAnd:
       __ And(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));

--- a/src/compiler/backend/riscv32/code-generator-riscv32.cc
+++ b/src/compiler/backend/riscv32/code-generator-riscv32.cc
@@ -986,38 +986,38 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
                      i.InputOperand(1), kScratchReg);
       break;
     case kRiscvMul32:
-      __ Mul32(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
+      __ Mul(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       break;
     case kRiscvMulOvf32:
       __ MulOverflow32(i.OutputRegister(), i.InputOrZeroRegister(0),
                        i.InputOperand(1), kScratchReg);
       break;
     case kRiscvMulHigh32:
-      __ Mulh32(i.OutputRegister(), i.InputOrZeroRegister(0),
+      __ Mulh(i.OutputRegister(), i.InputOrZeroRegister(0),
                 i.InputOperand(1));
       break;
     case kRiscvMulHighU32:
-      __ Mulhu32(i.OutputRegister(), i.InputOrZeroRegister(0),
+      __ Mulhu(i.OutputRegister(), i.InputOrZeroRegister(0),
                  i.InputOperand(1), kScratchReg, kScratchReg2);
       break;
     case kRiscvDiv32: {
-      __ Div32(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
+      __ Div(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       // Set ouput to zero if divisor == 0
       __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
     }
     case kRiscvDivU32: {
-      __ Divu32(i.OutputRegister(), i.InputOrZeroRegister(0),
+      __ Divu(i.OutputRegister(), i.InputOrZeroRegister(0),
                 i.InputOperand(1));
       // Set ouput to zero if divisor == 0
       __ LoadZeroIfConditionZero(i.OutputRegister(), i.InputRegister(1));
       break;
     }
     case kRiscvMod32:
-      __ Mod32(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
+      __ Mod(i.OutputRegister(), i.InputOrZeroRegister(0), i.InputOperand(1));
       break;
     case kRiscvModU32:
-      __ Modu32(i.OutputRegister(), i.InputOrZeroRegister(0),
+      __ Modu(i.OutputRegister(), i.InputOrZeroRegister(0),
                 i.InputOperand(1));
       break;
     case kRiscvAnd:

--- a/src/wasm/baseline/riscv32/liftoff-assembler-riscv32.h
+++ b/src/wasm/baseline/riscv32/liftoff-assembler-riscv32.h
@@ -1133,7 +1133,7 @@ bool LiftoffAssembler::emit_i64_popcnt(LiftoffRegister dst,
 }
 
 void LiftoffAssembler::emit_i32_mul(Register dst, Register lhs, Register rhs) {
-  TurboAssembler::Mul32(dst, lhs, rhs);
+  TurboAssembler::Mul(dst, lhs, rhs);
 }
 
 void LiftoffAssembler::emit_i32_divs(Register dst, Register lhs, Register rhs,
@@ -1148,25 +1148,25 @@ void LiftoffAssembler::emit_i32_divs(Register dst, Register lhs, Register rhs,
   TurboAssembler::Branch(trap_div_unrepresentable, eq, kScratchReg,
                          Operand(zero_reg));
 
-  TurboAssembler::Div32(dst, lhs, rhs);
+  TurboAssembler::Div(dst, lhs, rhs);
 }
 
 void LiftoffAssembler::emit_i32_divu(Register dst, Register lhs, Register rhs,
                                      Label* trap_div_by_zero) {
   TurboAssembler::Branch(trap_div_by_zero, eq, rhs, Operand(zero_reg));
-  TurboAssembler::Divu32(dst, lhs, rhs);
+  TurboAssembler::Divu(dst, lhs, rhs);
 }
 
 void LiftoffAssembler::emit_i32_rems(Register dst, Register lhs, Register rhs,
                                      Label* trap_div_by_zero) {
   TurboAssembler::Branch(trap_div_by_zero, eq, rhs, Operand(zero_reg));
-  TurboAssembler::Mod32(dst, lhs, rhs);
+  TurboAssembler::Mod(dst, lhs, rhs);
 }
 
 void LiftoffAssembler::emit_i32_remu(Register dst, Register lhs, Register rhs,
                                      Label* trap_div_by_zero) {
   TurboAssembler::Branch(trap_div_by_zero, eq, rhs, Operand(zero_reg));
-  TurboAssembler::Modu32(dst, lhs, rhs);
+  TurboAssembler::Modu(dst, lhs, rhs);
 }
 
 #define I32_BINOP(name, instruction)                                 \
@@ -1238,7 +1238,7 @@ I32_SHIFTOP_I(shr, srli)
 
 void LiftoffAssembler::emit_i64_mul(LiftoffRegister dst, LiftoffRegister lhs,
                                     LiftoffRegister rhs) {
-  TurboAssembler::Mul64(dst.gp(), lhs.gp(), rhs.gp());
+  TurboAssembler::Mul(dst.gp(), lhs.gp(), rhs.gp()); 
 }
 
 bool LiftoffAssembler::emit_i64_divs(LiftoffRegister dst, LiftoffRegister lhs,

--- a/src/wasm/baseline/riscv32/liftoff-assembler-riscv32.h
+++ b/src/wasm/baseline/riscv32/liftoff-assembler-riscv32.h
@@ -1238,7 +1238,7 @@ I32_SHIFTOP_I(shr, srli)
 
 void LiftoffAssembler::emit_i64_mul(LiftoffRegister dst, LiftoffRegister lhs,
                                     LiftoffRegister rhs) {
-  TurboAssembler::Mul(dst.gp(), lhs.gp(), rhs.gp()); 
+  TurboAssembler::Mul(dst.gp(), lhs.gp(), rhs.gp());
 }
 
 bool LiftoffAssembler::emit_i64_divs(LiftoffRegister dst, LiftoffRegister lhs,


### PR DESCRIPTION
This PR removes the '32' and '64' from mul, div, mod instructions and their variants. 