### PR TITLE
Port the rest (u)int64 to (u)int32

### DIFF
--- a/src/codegen/riscv32/assembler-riscv32-inl.h
+++ b/src/codegen/riscv32/assembler-riscv32-inl.h
@@ -50,7 +50,7 @@ bool CpuFeatures::SupportsOptimizer() { return IsSupported(FPU); }
 
 bool Operand::is_reg() const { return rm_.is_valid(); }
 
-int64_t Operand::immediate() const {
+int32_t Operand::immediate() const {
   DCHECK(!is_reg());
   DCHECK(!IsHeapObjectRequest());
   return value_.immediate;
@@ -91,7 +91,7 @@ Address RelocInfo::target_address_address() {
   // place, ready to be patched with the target. After jump optimization,
   // that is the address of the instruction that follows J/JAL/JR/JALR
   // instruction.
-  return pc_ + Assembler::kInstructionsFor64BitConstant * kInstrSize;
+  return pc_ + Assembler::kInstructionsFor32BitConstant * kInstrSize;
 }
 
 Address RelocInfo::constant_pool_entry_address() { UNREACHABLE(); }
@@ -142,7 +142,7 @@ int Assembler::deserialization_special_target_size(
 
 void Assembler::set_target_internal_reference_encoded_at(Address pc,
                                                          Address target) {
-  set_target_value_at(pc, static_cast<uint64_t>(target));
+  set_target_value_at(pc, static_cast<uint32_t>(target));
 }
 
 void Assembler::deserialization_set_target_internal_reference_at(

--- a/src/codegen/riscv32/assembler-riscv32.h
+++ b/src/codegen/riscv32/assembler-riscv32.h
@@ -62,7 +62,7 @@ class SafepointTableBuilder;
 // -----------------------------------------------------------------------------
 // Machine instruction Operands.
 constexpr int kSmiShift = kSmiTagSize + kSmiShiftSize;
-constexpr uint64_t kSmiShiftMask = (1UL << kSmiShift) - 1;
+constexpr uint32_t kSmiShiftMask = (1UL << kSmiShift) - 1;
 // Class Operand represents a shifter operand in data processing instructions.
 class Operand {
  public:
@@ -74,7 +74,7 @@ class Operand {
   }
   V8_INLINE explicit Operand(const ExternalReference& f)
       : rm_(no_reg), rmode_(RelocInfo::EXTERNAL_REFERENCE) {
-    value_.immediate = static_cast<int64_t>(f.address());
+    value_.immediate = static_cast<int32_t>(f.address());
   }
   V8_INLINE explicit Operand(const char* s);
   explicit Operand(Handle<HeapObject> handle);
@@ -92,7 +92,7 @@ class Operand {
   // Return true if this is a register operand.
   V8_INLINE bool is_reg() const;
 
-  inline int64_t immediate() const;
+  inline int32_t immediate() const;
 
   bool IsImmediate() const { return !rm_.is_valid(); }
 
@@ -118,7 +118,7 @@ class Operand {
   union Value {
     Value() {}
     HeapObjectRequest heap_object_request;  // if is_heap_object_request_
-    int64_t immediate;                      // otherwise
+    int32_t immediate;                      // otherwise
   } value_;                                 // valid if rm_ == no_reg
   bool is_heap_object_request_ = false;
   RelocInfo::Mode rmode_;
@@ -1398,7 +1398,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
   inline static void set_target_internal_reference_encoded_at(Address pc,
                                                               Address target);
 
-  int64_t buffer_space() const { return reloc_info_writer.pos() - pc_; }
+  int32_t buffer_space() const { return reloc_info_writer.pos() - pc_; }
 
   // Decode branch instruction at pos and return branch target pos.
   int target_at(int pos, bool is_internal);
@@ -1740,7 +1740,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
 
   // Internal reference positions, required for unbounded internal reference
   // labels.
-  std::set<int64_t> internal_reference_positions_;
+  std::set<int32_t> internal_reference_positions_;
   bool is_internal_reference(Label* L) {
     return internal_reference_positions_.find(L->pos()) !=
            internal_reference_positions_.end();

--- a/src/codegen/riscv32/macro-assembler-riscv32.h
+++ b/src/codegen/riscv32/macro-assembler-riscv32.h
@@ -537,13 +537,13 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   void LoadZeroIfConditionZero(Register dest, Register condition);
 
   void SignExtendByte(Register rd, Register rs) {
-    slli(rd, rs, 64 - 8);
-    srai(rd, rd, 64 - 8);
+    slli(rd, rs, 32 - 8);
+    srai(rd, rd, 32 - 8);
   }
 
   void SignExtendShort(Register rd, Register rs) {
-    slli(rd, rs, 64 - 16);
-    srai(rd, rd, 64 - 16);
+    slli(rd, rs, 32 - 16);
+    srai(rd, rd, 32 - 16);
   }
 
   void Clz32(Register rd, Register rs);

--- a/test/cctest/test-assembler-riscv32.cc
+++ b/test/cctest/test-assembler-riscv32.cc
@@ -1683,7 +1683,7 @@ TEST(jump_tables2) {
       __ BlockTrampolinePoolFor(kNumCases * 2 + 6);
 
       __ auipc(ra, 0);
-      __ slli(t3, a0, 3);
+      __ slli(t2, a0, 2);
       __ add(t3, t3, ra);
       __ Lw(t3, MemOperand(t3, 6 * kInstrSize));
       __ jr(t3);
@@ -1742,7 +1742,7 @@ TEST(jump_tables3) {
       __ BlockTrampolinePoolFor(kNumCases * 2 + 6);
       __ Align(4);
       __ auipc(ra, 0);
-      __ slli(t3, a0, 3);
+      __ slli(t2, a0, 2);
       __ add(t3, t3, ra);
       __ Lw(t3, MemOperand(t3, 6 * kInstrSize));
       __ jr(t3);

--- a/test/cctest/test-simple-riscv32.cc
+++ b/test/cctest/test-simple-riscv32.cc
@@ -65,7 +65,7 @@ TEST(RISCV_SIMPLE0) {
   Handle<Code> code =
       Factory::CodeBuilder(isolate, desc, CodeKind::FOR_TESTING).Build();
   auto f = GeneratedCode<F2>::FromCode(*code);
-  int64_t res = reinterpret_cast<int64_t>(f.Call(0xAB0, 0xC, 0, 0, 0));
+  int32_t res = reinterpret_cast<int32_t>(f.Call(0xAB0, 0xC, 0, 0, 0));
   CHECK_EQ(0xABCL, res);
 }
 
@@ -85,7 +85,7 @@ TEST(RISCV_SIMPLE1) {
   Handle<Code> code =
       Factory::CodeBuilder(isolate, desc, CodeKind::FOR_TESTING).Build();
   auto f = GeneratedCode<F1>::FromCode(*code);
-  int64_t res = reinterpret_cast<int64_t>(f.Call(100, 0, 0, 0, 0));
+  int32_t res = reinterpret_cast<int32_t>(f.Call(100, 0, 0, 0, 0));
   CHECK_EQ(99L, res);
 }
 
@@ -119,7 +119,7 @@ TEST(RISCV_SIMPLE2) {
   code->Print();
 #endif
   auto f = GeneratedCode<F1>::FromCode(*code);
-  int64_t res = reinterpret_cast<int64_t>(f.Call(100, 0, 0, 0, 0));
+  int32_t res = reinterpret_cast<int32_t>(f.Call(100, 0, 0, 0, 0));
   CHECK_EQ(5050, res);
 }
 
@@ -140,7 +140,7 @@ TEST(RISCV_SIMPLE3) {
   Handle<Code> code =
       Factory::CodeBuilder(isolate, desc, CodeKind::FOR_TESTING).Build();
   auto f = GeneratedCode<F1>::FromCode(*code);
-  int64_t res = reinterpret_cast<int64_t>(f.Call(255, 0, 0, 0, 0));
+  int32_t res = reinterpret_cast<int32_t>(f.Call(255, 0, 0, 0, 0));
   CHECK_EQ(-1, res);
 }
 
@@ -180,7 +180,7 @@ TEST(LI) {
   Handle<Code> code =
       Factory::CodeBuilder(isolate, desc, CodeKind::FOR_TESTING).Build();
   auto f = GeneratedCode<F1>::FromCode(*code);
-  int64_t res = reinterpret_cast<int64_t>(f.Call(0xDEADBEEF, 0, 0, 0, 0));
+  int32_t res = reinterpret_cast<int32_t>(f.Call(0xDEADBEEF, 0, 0, 0, 0));
   CHECK_EQ(0L, res);
 }
 
@@ -219,7 +219,7 @@ TEST(LI_CONST) {
   Handle<Code> code =
       Factory::CodeBuilder(isolate, desc, CodeKind::FOR_TESTING).Build();
   auto f = GeneratedCode<F1>::FromCode(*code);
-  int64_t res = reinterpret_cast<int64_t>(f.Call(0xDEADBEEF, 0, 0, 0, 0));
+  int32_t res = reinterpret_cast<int32_t>(f.Call(0xDEADBEEF, 0, 0, 0, 0));
   CHECK_EQ(0L, res);
 }
 


### PR DESCRIPTION
Now cctest only has 64 failures.
And almost all these failures are related to wasm.